### PR TITLE
[Test] User 도메인, 회원가입 테스트 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'io.rest-assured:rest-assured'
 	testImplementation 'com.h2database:h2'
 }
 

--- a/src/main/java/real/world/domain/user/controller/UserController.java
+++ b/src/main/java/real/world/domain/user/controller/UserController.java
@@ -1,13 +1,14 @@
 package real.world.domain.user.controller;
 
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import real.world.domain.user.service.UserService;
 import real.world.domain.user.dto.request.RegisterRequest;
 import real.world.domain.user.dto.response.RegisterResponse;
+import real.world.domain.user.service.UserService;
 
 @RestController
 public class UserController {
@@ -23,7 +24,7 @@ public class UserController {
         @RequestBody @Valid RegisterRequest registerRequest) {
         final RegisterResponse response = userService.register(registerRequest);
 
-        return ResponseEntity.ok(response);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
 }

--- a/src/main/java/real/world/domain/user/dto/response/RegisterResponse.java
+++ b/src/main/java/real/world/domain/user/dto/response/RegisterResponse.java
@@ -2,19 +2,21 @@ package real.world.domain.user.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonRootName;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import real.world.domain.user.entity.User;
 
 @Getter
 @JsonRootName(value = "user")
+@NoArgsConstructor
 public class RegisterResponse {
 
-    private final String username;
+    private String username;
 
-    private final String email;
+    private String email;
 
-    private final String bio;
+    private String bio;
 
-    private final String image;
+    private String image;
 
     private RegisterResponse(String username, String email, String bio, String image) {
         this.username = username;

--- a/src/main/java/real/world/domain/user/entity/User.java
+++ b/src/main/java/real/world/domain/user/entity/User.java
@@ -5,11 +5,19 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.Getter;
 
 @Getter
 @Entity(name = "users")
 public class User {
+
+    private static final int MAX_USERNAME_LENGTH = 15;
+
+    private static final int MAX_EMAIL_LENGTH = 15;
+
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[a-z0-9._-]+@[a-z]+[.]+[a-z]{2,3}$");
 
     @Id
     @Column(name = "user_id")
@@ -39,5 +47,27 @@ public class User {
         this.email = email;
         this.bio = bio;
         this.imageUrl = imageUrl;
+        validate();
     }
+
+    private void validate() {
+        validateUsername();
+        validateEmail();
+    }
+
+    private void validateUsername() {
+        if(this.username.length() > MAX_USERNAME_LENGTH) {
+            throw new IllegalArgumentException("username too long");
+        }
+    }
+
+    private void validateEmail() {
+        if(this.email.length() > MAX_EMAIL_LENGTH) {
+            throw new IllegalArgumentException("email too long");
+        }
+        if(!EMAIL_PATTERN.matcher(email).matches()) {
+            throw new IllegalArgumentException("wrong email pattern");
+        }
+    }
+
 }

--- a/src/main/java/real/world/domain/user/service/UserService.java
+++ b/src/main/java/real/world/domain/user/service/UserService.java
@@ -28,7 +28,7 @@ public class UserService {
 
     public RegisterResponse register(RegisterRequest registerRequest) {
         if (userRepository.existsByUsername(registerRequest.getUsername())) {
-            throw new RuntimeException("이미있음"); // TODO 예외처리
+            throw new IllegalArgumentException("이미 존재하는 유저네임"); // TODO 예외처리
         }
         final User user = requestToEntity(registerRequest);
         userRepository.save(user);

--- a/src/test/java/real/world/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/real/world/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,64 @@
+package real.world.domain.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static real.world.fixture.UserFixtures.JOHN;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import jakarta.annotation.PostConstruct;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import real.world.config.SecurityConfig;
+import real.world.domain.user.dto.request.RegisterRequest;
+import real.world.domain.user.dto.response.RegisterResponse;
+import real.world.domain.user.entity.User;
+import real.world.domain.user.service.UserService;
+
+@WebMvcTest
+@Import({SecurityConfig.class})
+public class UserControllerTest {
+
+    @MockBean
+    private UserService userService;
+
+    @Autowired
+    private MockMvc mockmvc;
+
+    private ObjectMapper objectMapper;
+
+    @PostConstruct
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.enable(SerializationFeature.WRAP_ROOT_VALUE);
+    }
+
+    @Test
+    void 회원가입_성공() throws Exception {
+        // given
+        final User user = JOHN.생성();
+        final RegisterRequest request = JOHN.회원가입을_한다();
+        given(userService.register(any())).willReturn(RegisterResponse.of(user));
+
+        // when
+        final ResultActions resultActions = mockmvc.perform(
+            post("/api/users").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        resultActions.andExpect(status().isCreated()).andDo(print());
+
+        verify(userService).register(any());
+    }
+
+}

--- a/src/test/java/real/world/domain/user/entity/UserTest.java
+++ b/src/test/java/real/world/domain/user/entity/UserTest.java
@@ -1,0 +1,51 @@
+package real.world.domain.user.entity;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+public class UserTest {
+
+    @Test
+    void 회원의_username이_너무_길면_예외를_던진다() {
+        // given & when & then
+        assertThatThrownBy(
+            () -> new User(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "1234",
+                "aaa@email.com",
+                "",
+                "image.png"
+            )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 회원의_email이_너무_길면_예외를_던진다() {
+        // given & when & then
+        assertThatThrownBy(
+            () -> new User(
+                "john",
+                "1234",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@email.com",
+                "",
+                "image.png"
+            )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 회원의_email이_잘못된_형식이면_예외를_던진다() {
+        // given & when & then
+        assertThatThrownBy(
+            () -> new User(
+                "john",
+                "1234",
+                "aaaaemail.com",
+                "",
+                "image.png"
+            )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+}

--- a/src/test/java/real/world/domain/user/service/UserServiceTest.java
+++ b/src/test/java/real/world/domain/user/service/UserServiceTest.java
@@ -1,0 +1,65 @@
+package real.world.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static real.world.fixture.UserFixtures.JOHN;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import real.world.domain.user.dto.request.RegisterRequest;
+import real.world.domain.user.dto.response.RegisterResponse;
+import real.world.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    private final UserRepository userRepository = BDDMockito.mock(UserRepository.class);
+
+    private final PasswordEncoder passwordEncoder = NoOpPasswordEncoder.getInstance();
+
+    private final UserService userService = new UserService(userRepository, passwordEncoder);
+
+    @Nested
+    class 회원가입은 {
+
+        @Test
+        void 정상_호출시_회원가입을_하고_응답을_반환한다() {
+            // given
+            final RegisterRequest request = JOHN.회원가입을_한다();
+
+            // when
+            final RegisterResponse response = userService.register(request);
+
+            // then
+            assertAll(() -> {
+                verify(userRepository).save(any());
+                assertThat(response.getUsername()).isEqualTo(JOHN.getUsername());
+                assertThat(response.getEmail()).isEqualTo(JOHN.getEmail());
+            });
+        }
+
+        @Test
+        void 유저네임_중복_시_예외를_던진다() {
+            // given
+            given(userRepository.existsByUsername(JOHN.getUsername())).willReturn(true);
+
+            final RegisterRequest request = JOHN.회원가입을_한다();
+
+            // when & then
+            assertThatThrownBy(
+                () -> userService.register(request)
+            ).isInstanceOf(IllegalArgumentException.class);
+        }
+
+    }
+
+}

--- a/src/test/java/real/world/e2e/RestAssuredUtils.java
+++ b/src/test/java/real/world/e2e/RestAssuredUtils.java
@@ -1,0 +1,27 @@
+package real.world.e2e;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+public class RestAssuredUtils {
+
+    public static ExtractableResponse<Response> GET_요청을_보낸다(String url) {
+        return RestAssured
+            .given().log().all()
+            .when().get(url)
+            .then().log().all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> POST_요청을_보낸다(String url, Object body) {
+        return RestAssured
+            .given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE).body(body)
+            .when().post(url)
+            .then().log().all()
+            .extract();
+    }
+
+}

--- a/src/test/java/real/world/e2e/UserE2ETest.java
+++ b/src/test/java/real/world/e2e/UserE2ETest.java
@@ -1,0 +1,60 @@
+package real.world.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static real.world.e2e.RestAssuredUtils.POST_요청을_보낸다;
+import static real.world.fixture.UserFixtures.JOHN;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.restassured.RestAssured;
+import io.restassured.config.ObjectMapperConfig;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import real.world.domain.user.dto.request.RegisterRequest;
+import real.world.domain.user.dto.response.RegisterResponse;
+
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+public class UserE2ETest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enable(SerializationFeature.WRAP_ROOT_VALUE);
+        objectMapper.enable(DeserializationFeature.UNWRAP_ROOT_VALUE);
+        RestAssured.config = RestAssured.config()
+            .objectMapperConfig(new ObjectMapperConfig().jackson2ObjectMapperFactory(
+                (cls, charset) -> objectMapper
+            ));
+    }
+
+    @Test
+    void 회원가입을_한다() {
+        // given
+        final RegisterRequest request = JOHN.회원가입을_한다();
+
+        // when
+        final ExtractableResponse<Response> extractableResponse = POST_요청을_보낸다("/api/users",
+            request);
+        final RegisterResponse response = extractableResponse.as(RegisterResponse.class);
+
+        // then
+        assertAll(() -> {
+            assertThat(extractableResponse.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+            assertThat(response.getUsername()).isEqualTo(JOHN.getUsername());
+            assertThat(response.getEmail()).isEqualTo(JOHN.getEmail());
+        });
+    }
+
+}

--- a/src/test/java/real/world/fixture/UserFixtures.java
+++ b/src/test/java/real/world/fixture/UserFixtures.java
@@ -9,8 +9,8 @@ import real.world.domain.user.entity.User;
 public enum UserFixtures {
 
     JOHN("John", "1234", "john@email.com", "im john", "john.png"),
-    Alice("Alice", "1234", "alice@email.com", "im alice", "alice.png"),
-    Bob("Bob", "1234", "bob@email.com", "im bob", "bob.png");
+    ALICE("Alice", "1234", "alice@email.com", "im alice", "alice.png"),
+    BOB("Bob", "1234", "bob@email.com", "im bob", "bob.png");
 
     private final String username;
     private final String password;

--- a/src/test/java/real/world/fixture/UserFixtures.java
+++ b/src/test/java/real/world/fixture/UserFixtures.java
@@ -1,0 +1,71 @@
+package real.world.fixture;
+
+import org.springframework.test.util.ReflectionTestUtils;
+import real.world.domain.user.dto.request.RegisterRequest;
+import real.world.domain.user.entity.User;
+
+public enum UserFixtures {
+
+    JOHN("John", "1234", "john@email.com", "im john", "john.png"),
+    Alice("Alice", "1234", "alice@email.com", "im alice", "alice.png"),
+    Bob("Bob", "1234", "bob@email.com", "im bob", "bob.png");
+
+    private final String username;
+    private final String password;
+    private final String email;
+    private final String bio;
+    private final String imageUrl;
+
+    UserFixtures(String username, String password, String email, String bio, String imageUrl) {
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.bio = bio;
+        this.imageUrl = imageUrl;
+    }
+
+    public User 생성() {
+        return 생성(0L);
+    }
+
+    public User 생성(Long id) {
+        final User user = new User(
+            this.username,
+            this.password,
+            this.email,
+            this.bio,
+            this.imageUrl
+        );
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    public RegisterRequest 회원가입을_한다() {
+        final RegisterRequest request = new RegisterRequest();
+        ReflectionTestUtils.setField(request, "username", this.username);
+        ReflectionTestUtils.setField(request, "password", this.password);
+        ReflectionTestUtils.setField(request, "email", this.email);
+        return request;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+}

--- a/src/test/java/real/world/fixture/UserFixtures.java
+++ b/src/test/java/real/world/fixture/UserFixtures.java
@@ -1,9 +1,11 @@
 package real.world.fixture;
 
+import lombok.Getter;
 import org.springframework.test.util.ReflectionTestUtils;
 import real.world.domain.user.dto.request.RegisterRequest;
 import real.world.domain.user.entity.User;
 
+@Getter
 public enum UserFixtures {
 
     JOHN("John", "1234", "john@email.com", "im john", "john.png"),
@@ -46,26 +48,6 @@ public enum UserFixtures {
         ReflectionTestUtils.setField(request, "password", this.password);
         ReflectionTestUtils.setField(request, "email", this.email);
         return request;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public String getBio() {
-        return bio;
-    }
-
-    public String getImageUrl() {
-        return imageUrl;
     }
 
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,24 @@
+server:
+  port: 8083
+
+spring:
+  jackson:
+    deserialization:
+      unwrap-root-value: true
+    serialization:
+      wrap-root-value: true
+
+  datasource:
+    url: jdbc:h2:mem:test_real;MODE=MYSQL;
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+      show_sql: true
+    open-in-view: false
+
+base:
+  bio: Hello!
+  img:
+    url: image.png


### PR DESCRIPTION
##  📣요약
- User 도메인 테스트 작성
- 회원가입 테스트 작성
## ✨ 세부 내용
### 기존 코드 수정
- 테스트에 의존성 추가(lombok, restassured)
- API 스펙에 맞게, 회원가입 API 응답 코드를 `CREATE`로 수정
- 이전 PR에 누락된 User 도메인 검증 추가
- `UserService`내 예외를 `IllegalArgumentException`로 수정
### 테스트 작성
- User 도메인 엔티티 테스트 작성
- 회원가입 API 관련 테스트 작성
- 테스트 관련 유틸
    - `RestAssuredUtil` 작성
    - `UserFixtures` 작성