### PR TITLE
[Feautre] 예외처리 추가

### DIFF
--- a/src/main/java/real/world/domain/user/entity/User.java
+++ b/src/main/java/real/world/domain/user/entity/User.java
@@ -8,6 +8,8 @@ import jakarta.persistence.Id;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.Getter;
+import real.world.error.exception.EmailInvalidException;
+import real.world.error.exception.UsernameInvalidException;
 
 @Getter
 @Entity(name = "users")
@@ -57,16 +59,13 @@ public class User {
 
     private void validateUsername() {
         if(this.username.length() > MAX_USERNAME_LENGTH) {
-            throw new IllegalArgumentException("username too long");
+            throw new UsernameInvalidException();
         }
     }
 
     private void validateEmail() {
-        if(this.email.length() > MAX_EMAIL_LENGTH) {
-            throw new IllegalArgumentException("email too long");
-        }
-        if(!EMAIL_PATTERN.matcher(email).matches()) {
-            throw new IllegalArgumentException("wrong email pattern");
+        if(this.email.length() > MAX_EMAIL_LENGTH || !EMAIL_PATTERN.matcher(email).matches()) {
+            throw new EmailInvalidException();
         }
     }
 

--- a/src/main/java/real/world/domain/user/service/UserService.java
+++ b/src/main/java/real/world/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import real.world.domain.user.dto.request.RegisterRequest;
 import real.world.domain.user.dto.response.RegisterResponse;
 import real.world.domain.user.entity.User;
 import real.world.domain.user.repository.UserRepository;
+import real.world.error.exception.UsernameAlreadyExistsException;
 
 @Service
 public class UserService {
@@ -28,7 +29,7 @@ public class UserService {
 
     public RegisterResponse register(RegisterRequest registerRequest) {
         if (userRepository.existsByUsername(registerRequest.getUsername())) {
-            throw new IllegalArgumentException("이미 존재하는 유저네임"); // TODO 예외처리
+            throw new UsernameAlreadyExistsException();
         }
         final User user = requestToEntity(registerRequest);
         userRepository.save(user);

--- a/src/main/java/real/world/error/ErrorCode.java
+++ b/src/main/java/real/world/error/ErrorCode.java
@@ -1,0 +1,39 @@
+package real.world.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    // Global
+    REQUEST_INVALID(HttpStatus.UNPROCESSABLE_ENTITY, "request", "invalid."),
+    INTERNAL_SERVER(HttpStatus.UNPROCESSABLE_ENTITY, "internal", "server error."),
+
+
+    // User
+    USERNAME_INVALID(HttpStatus.UNPROCESSABLE_ENTITY, "username", "invalid."),
+    EMAIL_INVALID(HttpStatus.UNPROCESSABLE_ENTITY, "email", "invalid."),
+    USERNAME_ALREADY_EXIST(HttpStatus.UNPROCESSABLE_ENTITY, "username", "already exists.");
+
+    private final HttpStatus code;
+
+    private final String body;
+
+    private final String message;
+
+    ErrorCode(HttpStatus code, String body, String message) {
+        this.code = code;
+        this.body = body;
+        this.message = message;
+    }
+
+    ErrorCode(HttpStatus code) {
+        this(code, "", "");
+    }
+
+    ErrorCode(HttpStatus code, String message) {
+        this(code, "", message);
+    }
+
+}

--- a/src/main/java/real/world/error/ErrorResponse.java
+++ b/src/main/java/real/world/error/ErrorResponse.java
@@ -1,0 +1,44 @@
+package real.world.error;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import real.world.error.exception.BusinessException;
+
+@JsonRootName(value = "errors")
+public class ErrorResponse {
+
+    private final Map<String, String> errors;
+
+    private ErrorResponse(Map<String, String> errors) {
+        this.errors = errors;
+    }
+
+    public static ErrorResponse of() {
+        return new ErrorResponse(Collections.emptyMap());
+    }
+
+    public static ErrorResponse of(Map<String, String> errors) {
+        return new ErrorResponse(errors);
+    }
+
+    public static ErrorResponse of(BusinessException e) {
+        final Map<String, String> errors = new HashMap<>();
+        errors.put(e.getBody(), e.getMessage());
+        return new ErrorResponse(errors);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        final Map<String, String> errors = new HashMap<>();
+        errors.put(errorCode.getBody(), errorCode.getMessage());
+        return new ErrorResponse(errors);
+    }
+
+    @JsonAnyGetter
+    public Map<String, String> getErrors() {
+        return errors;
+    }
+
+}

--- a/src/main/java/real/world/error/GlobalExceptionHandler.java
+++ b/src/main/java/real/world/error/GlobalExceptionHandler.java
@@ -1,0 +1,98 @@
+package real.world.error;
+
+import static real.world.error.ErrorCode.INTERNAL_SERVER;
+import static real.world.error.ErrorCode.REQUEST_INVALID;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestValueException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
+import real.world.error.exception.BusinessException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler({
+        MissingServletRequestPartException.class,
+        MissingRequestValueException.class,
+        MethodArgumentTypeMismatchException.class,
+        HttpMessageNotReadableException.class,
+        HttpRequestMethodNotSupportedException.class
+    })
+    public ResponseEntity<ErrorResponse> handleRequestException(Exception e) {
+        final ErrorResponse errorResponse = ErrorResponse.of(REQUEST_INVALID);
+        return new ResponseEntity<>(errorResponse, REQUEST_INVALID.getCode());
+    }
+
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleConstraintViolationException(
+        ConstraintViolationException e) {
+        final ErrorResponse response = ErrorResponse.of(
+            convertConstraintViolations(e.getConstraintViolations()));
+        return new ResponseEntity<>(response, REQUEST_INVALID.getCode());
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+        MethodArgumentNotValidException e) {
+        final ErrorResponse response = ErrorResponse.of(convertBindingResult(e.getBindingResult()));
+        return new ResponseEntity<>(response, REQUEST_INVALID.getCode());
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        final ErrorResponse response = ErrorResponse.of(convertBindingResult(e.getBindingResult()));
+        return new ResponseEntity<>(response, REQUEST_INVALID.getCode());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        final ErrorResponse errorResponse = ErrorResponse.of(e);
+        return new ResponseEntity<>(errorResponse, e.getHttpStatus());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        final ErrorResponse errorResponse = ErrorResponse.of(INTERNAL_SERVER);
+        return new ResponseEntity<>(errorResponse, INTERNAL_SERVER.getCode());
+    }
+
+    private Map<String, String> convertBindingResult(BindingResult bindingResult) {
+        final List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+        return fieldErrors.stream()
+            .collect(Collectors.toMap(
+                FieldError::getField,
+                error -> error.getDefaultMessage() == null ? error.getDefaultMessage() : ""
+            ));
+    }
+
+    private Map<String, String> convertConstraintViolations(
+        Set<ConstraintViolation<?>> constraintViolations) {
+        return constraintViolations.stream()
+            .collect(Collectors.toMap(
+                error -> {
+                    final int index = error.getPropertyPath().toString().indexOf(".");
+                    return error.getPropertyPath().toString().substring(index + 1);
+                },
+                ConstraintViolation::getMessage
+            ));
+    }
+
+}

--- a/src/main/java/real/world/error/exception/BusinessException.java
+++ b/src/main/java/real/world/error/exception/BusinessException.java
@@ -1,0 +1,27 @@
+package real.world.error.exception;
+
+import org.springframework.http.HttpStatus;
+import real.world.error.ErrorCode;
+
+public abstract class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return errorCode.getCode();
+    }
+
+    public String getBody() {
+        return errorCode.getBody();
+    }
+
+    @Override
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+}

--- a/src/main/java/real/world/error/exception/EmailInvalidException.java
+++ b/src/main/java/real/world/error/exception/EmailInvalidException.java
@@ -1,0 +1,11 @@
+package real.world.error.exception;
+
+import real.world.error.ErrorCode;
+
+public class EmailInvalidException extends BusinessException{
+
+    public EmailInvalidException() {
+        super(ErrorCode.EMAIL_INVALID);
+    }
+
+}

--- a/src/main/java/real/world/error/exception/UsernameAlreadyExistsException.java
+++ b/src/main/java/real/world/error/exception/UsernameAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package real.world.error.exception;
+
+import real.world.error.ErrorCode;
+
+public class UsernameAlreadyExistsException extends BusinessException{
+
+    public UsernameAlreadyExistsException() {
+        super(ErrorCode.USERNAME_ALREADY_EXIST);
+    }
+
+}

--- a/src/main/java/real/world/error/exception/UsernameInvalidException.java
+++ b/src/main/java/real/world/error/exception/UsernameInvalidException.java
@@ -1,0 +1,11 @@
+package real.world.error.exception;
+
+import real.world.error.ErrorCode;
+
+public class UsernameInvalidException extends BusinessException{
+
+    public UsernameInvalidException() {
+        super(ErrorCode.USERNAME_INVALID);
+    }
+
+}

--- a/src/test/java/real/world/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/real/world/domain/user/controller/UserControllerTest.java
@@ -11,6 +11,7 @@ import static real.world.fixture.UserFixtures.JOHN;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import jakarta.annotation.PostConstruct;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -24,6 +25,7 @@ import real.world.domain.user.dto.request.RegisterRequest;
 import real.world.domain.user.dto.response.RegisterResponse;
 import real.world.domain.user.entity.User;
 import real.world.domain.user.service.UserService;
+import real.world.error.exception.UsernameAlreadyExistsException;
 
 @WebMvcTest
 @Import({SecurityConfig.class})
@@ -43,22 +45,41 @@ public class UserControllerTest {
         objectMapper.enable(SerializationFeature.WRAP_ROOT_VALUE);
     }
 
-    @Test
-    void 회원가입_성공() throws Exception {
-        // given
-        final User user = JOHN.생성();
-        final RegisterRequest request = JOHN.회원가입을_한다();
-        given(userService.register(any())).willReturn(RegisterResponse.of(user));
+    @Nested
+    class 회원가입 {
 
-        // when
-        final ResultActions resultActions = mockmvc.perform(
-            post("/api/users").contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)));
 
-        // then
-        resultActions.andExpect(status().isCreated()).andDo(print());
+        @Test
+        void 상태코드_201로_성공() throws Exception {
+            // given
+            final User user = JOHN.생성();
+            final RegisterRequest request = JOHN.회원가입을_한다();
+            given(userService.register(any())).willReturn(RegisterResponse.of(user));
 
-        verify(userService).register(any());
+            // when
+            final ResultActions resultActions = mockmvc.perform(
+                post("/api/users").contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // then
+            resultActions.andExpect(status().isCreated()).andDo(print());
+            verify(userService).register(any());
+        }
+
+        @Test
+        void 유저네임_중복시_상태코드_422로_실패() throws Exception {
+            // given
+            final RegisterRequest request = JOHN.회원가입을_한다();
+            given(userService.register(any())).willThrow(new UsernameAlreadyExistsException());
+
+            // when
+            final ResultActions resultActions = mockmvc.perform(
+                post("/api/users").contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // then
+            resultActions.andExpect(status().isUnprocessableEntity()).andDo(print());
+            verify(userService).register(any());
+        }
     }
-
 }

--- a/src/test/java/real/world/domain/user/entity/UserTest.java
+++ b/src/test/java/real/world/domain/user/entity/UserTest.java
@@ -3,6 +3,8 @@ package real.world.domain.user.entity;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
+import real.world.error.exception.EmailInvalidException;
+import real.world.error.exception.UsernameInvalidException;
 
 public class UserTest {
 
@@ -17,7 +19,7 @@ public class UserTest {
                 "",
                 "image.png"
             )
-        ).isInstanceOf(IllegalArgumentException.class);
+        ).isInstanceOf(UsernameInvalidException.class);
     }
 
     @Test
@@ -31,7 +33,7 @@ public class UserTest {
                 "",
                 "image.png"
             )
-        ).isInstanceOf(IllegalArgumentException.class);
+        ).isInstanceOf(EmailInvalidException.class);
     }
 
     @Test
@@ -45,7 +47,7 @@ public class UserTest {
                 "",
                 "image.png"
             )
-        ).isInstanceOf(IllegalArgumentException.class);
+        ).isInstanceOf(EmailInvalidException.class);
     }
 
 }

--- a/src/test/java/real/world/domain/user/service/UserServiceTest.java
+++ b/src/test/java/real/world/domain/user/service/UserServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import real.world.domain.user.dto.request.RegisterRequest;
 import real.world.domain.user.dto.response.RegisterResponse;
 import real.world.domain.user.repository.UserRepository;
+import real.world.error.exception.UsernameAlreadyExistsException;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
@@ -57,7 +58,7 @@ public class UserServiceTest {
             // when & then
             assertThatThrownBy(
                 () -> userService.register(request)
-            ).isInstanceOf(IllegalArgumentException.class);
+            ).isInstanceOf(UsernameAlreadyExistsException.class);
         }
 
     }


### PR DESCRIPTION
##  📣요약
- 커스텀 예외 및 예외 처리 추가
- 이에 따라 기존 코드 일부 수정
## ✨ 세부 내용
### 커스텀 예외 추가
- 편한 에러 처리를 위해 `ErrorCode` 작성
- `BusinessException`을 통해 `ErrorCode`를 캡슐화함.
- 기존의 `IlleagalArgumentException`을 커스텀 예외로 대체
- `ControllerAdvice`에서 발생할 수 있는 예외에 대한 처리
  - `ErrorResponse`를 통해 공통된 API 응답 처리
### 기존 코드 수정
- 기존의 `IlleagalArgumentException`을 커스텀 예외로 대체
- 테스트 수정
  - 컨트롤러 테스트 시 예외 처리 상황 추가
  - 기존 테스트 예외 검증 수정
