### PR TITLE
[Feature] Restdocs + Swagger-UI 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 
 	// restdocs + swagger
-	id 'com.epages.restdocs-api-spec' version '0.17.1'
+	id 'com.epages.restdocs-api-spec' version '0.18.2'
 	id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
@@ -47,7 +47,7 @@ dependencies {
 	testImplementation 'io.rest-assured:rest-assured'
 	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.17.1'
+	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.18.2'
 }
 
 test {
@@ -59,7 +59,7 @@ tasks.withType(GenerateSwaggerUI).configureEach {
 
 	delete file('src/main/resources/static/docs/')
 	copy {
-		from "build/resources/main/static/docs/"
+		from "build/docs/"
 		into "src/main/resources/static/docs/"
 	}
 }
@@ -69,8 +69,6 @@ bootJar{
 }
 
 openapi3 {
-	mkdir 'build/resources/main/static/docs'
-
 	server = "http://localhost:8080"
 	title = "Swagger API Docs"
 	description = "Spring REST Docs with SwaggerUI."
@@ -78,6 +76,6 @@ openapi3 {
 	outputFileNamePrefix = 'open-api'
 	format = 'json'
 
-	outputDirectory = 'build/resources/main/static/docs'
+	outputDirectory = 'build/docs'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,11 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.2'
 	id 'io.spring.dependency-management' version '1.1.2'
+
+
+	// restdocs + swagger
+	id 'com.epages.restdocs-api-spec' version '0.17.1'
+	id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 group = 'real'
@@ -28,8 +33,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
@@ -37,8 +46,35 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'io.rest-assured:rest-assured'
 	testImplementation 'com.h2database:h2'
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.17.1'
 }
 
-tasks.named('test') {
+test {
 	useJUnitPlatform()
+}
+
+tasks.withType(GenerateSwaggerUI).configureEach {
+	dependsOn 'openapi3'
+
+	delete file('src/main/resources/static/docs/')
+	copy {
+		from "build/resources/main/static/docs/"
+		into "src/main/resources/static/docs/"
+	}
+}
+
+bootJar{
+	dependsOn(':openapi3')
+}
+
+openapi3 {
+	server = "http://localhost:8080"
+	title = "Swagger API Docs"
+	description = "Spring REST Docs with SwaggerUI."
+	version = "0.0.1"
+	outputFileNamePrefix = 'open-api'
+	format = 'json'
+
+	outputDirectory = 'build/resources/main/static/docs'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,8 @@ bootJar{
 }
 
 openapi3 {
+	mkdir 'build/resources/main/static/docs'
+
 	server = "http://localhost:8080"
 	title = "Swagger API Docs"
 	description = "Spring REST Docs with SwaggerUI."
@@ -78,3 +80,4 @@ openapi3 {
 
 	outputDirectory = 'build/resources/main/static/docs'
 }
+

--- a/src/main/java/real/world/config/SecurityConfig.java
+++ b/src/main/java/real/world/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private static final String[] AUTH_PATH = {"/api/users", "/api/users/login"};
+    private static final String[] SWAGGER_PATH = {"/docs/open-api.json", "/swagger-ui/**", "/v3/**"};
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -27,6 +28,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(
                 auth ->
                     auth.requestMatchers(HttpMethod.POST, AUTH_PATH).permitAll()
+                        .requestMatchers(HttpMethod.GET, SWAGGER_PATH).permitAll()
                         .anyRequest().authenticated()
             );
         return http.build();

--- a/src/main/resources/application-web-local.yml
+++ b/src/main/resources/application-web-local.yml
@@ -16,3 +16,10 @@ spring:
       unwrap-root-value: true
     serialization:
       wrap-root-value: true
+
+
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    url: /docs/open-api.json

--- a/src/test/java/real/world/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/real/world/domain/user/controller/UserControllerTest.java
@@ -1,9 +1,10 @@
 package real.world.domain.user.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static real.world.fixture.UserFixtures.JOHN;
@@ -13,11 +14,14 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import jakarta.annotation.PostConstruct;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import real.world.config.SecurityConfig;
@@ -29,6 +33,8 @@ import real.world.error.exception.UsernameAlreadyExistsException;
 
 @WebMvcTest
 @Import({SecurityConfig.class})
+@AutoConfigureRestDocs
+@ExtendWith({RestDocumentationExtension.class})
 public class UserControllerTest {
 
     @MockBean
@@ -48,7 +54,6 @@ public class UserControllerTest {
     @Nested
     class 회원가입 {
 
-
         @Test
         void 상태코드_201로_성공() throws Exception {
             // given
@@ -62,7 +67,9 @@ public class UserControllerTest {
                     .content(objectMapper.writeValueAsString(request)));
 
             // then
-            resultActions.andExpect(status().isCreated()).andDo(print());
+            resultActions.andExpect(status().isCreated())
+                .andDo(document("register"))
+                .andDo(print());
             verify(userService).register(any());
         }
 
@@ -78,7 +85,8 @@ public class UserControllerTest {
                     .content(objectMapper.writeValueAsString(request)));
 
             // then
-            resultActions.andExpect(status().isUnprocessableEntity()).andDo(print());
+            resultActions.andExpect(status().isUnprocessableEntity())
+                .andDo(print());
             verify(userService).register(any());
         }
     }


### PR DESCRIPTION
##  📣요약
- Restdocs + Swagger-UI 추가
## ✨ 세부 내용
- `Controller` 테스트 시 `document()`를 통해 자동으로 API 문서 작성
  - `openapi` 관련 플러그인, 의존성을 통해 `json`이 결과물로 나옴
- `Swagger-UI`는 해당 `json`을 통해 애플리케이션 실행 시 API 문서 페이지를 지원
- `SecurityConfig`에서 Swagger 경로 관련 설정 추가
- 미해결 문제 #7 