### PR TITLE
[Feature] 아티클 업로드 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-
+src/main/resources/static/docs/open-api.yaml
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ openapi3 {
 	description = "Spring REST Docs with SwaggerUI."
 	version = "0.0.1"
 	outputFileNamePrefix = 'open-api'
-	format = 'json'
+	format = 'yaml'
 
 	outputDirectory = 'build/docs'
 }

--- a/http/article.http
+++ b/http/article.http
@@ -43,6 +43,10 @@ Content-Type: application/json
   "article": {
     "title": "title",
     "description": "desc",
-    "body": "body"
+    "body": "body",
+    "tagList": [
+      "tag1",
+      "tag2"
+    ]
   }
 }

--- a/http/article.http
+++ b/http/article.http
@@ -1,0 +1,48 @@
+### 회원가입
+POST {{domain}}/api/users
+Content-Type: application/json
+
+{
+  "user": {
+    "username": "username",
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+### 로그인
+POST {{domain}}/api/users/login
+Content-Type: application/json
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+> {%
+  const token = response.headers.valueOf("Authorization");
+
+  client.test("Validate", function() {
+    client.assert(response.status === 201, "Response status invalid");
+    client.assert(response.contentType.mimeType === "application/json", "Content-type invalid");
+    client.assert(response.headers.valueOf("Authorization").startsWith("BEARER") === true, "Authorization invalid");
+  });
+
+  client.log(token);
+  client.global.set("access_token", token);
+%}
+
+### 업로드
+POST {{domain}}/api/articles
+Authorization: {{access_token}}
+Content-Type: application/json
+
+{
+  "article": {
+    "title": "title",
+    "description": "desc",
+    "body": "body"
+  }
+}

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,0 +1,8 @@
+{
+  "local": {
+    "domain": "localhost:8080"
+  },
+  "server": {
+    "domian": ""
+  }
+}

--- a/http/user.http
+++ b/http/user.http
@@ -1,0 +1,40 @@
+### 회원가입
+POST {{domain}}/api/users
+Content-Type: application/json
+
+{
+  "user": {
+    "username": "username",
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+### 로그인
+POST {{domain}}/api/users/login
+Content-Type: application/json
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+> {%
+  const token = response.headers.valueOf("Authorization");
+
+  client.test("Validate", function() {
+    client.assert(response.status === 201, "Response status invalid");
+    client.assert(response.contentType.mimeType === "application/json", "Content-type invalid");
+    client.assert(response.headers.valueOf("Authorization").startsWith("BEARER") === true, "Authorization invalid");
+  });
+
+  client.log(token);
+  client.global.set("access_token", token);
+%}
+
+### 프로필
+GET {{domain}}/api/profiles
+Authorization: {{access_token}}
+Content-Type: application/json

--- a/src/main/java/real/world/domain/article/controller/ArticleController.java
+++ b/src/main/java/real/world/domain/article/controller/ArticleController.java
@@ -1,0 +1,31 @@
+package real.world.domain.article.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import real.world.domain.article.dto.request.UploadRequest;
+import real.world.domain.article.dto.response.UploadResponse;
+import real.world.domain.article.service.ArticleService;
+import real.world.domain.auth.annotation.Auth;
+
+@RestController
+public class ArticleController {
+
+    private final ArticleService articleService;
+
+    public ArticleController(ArticleService articleService) {
+        this.articleService = articleService;
+    }
+
+    @PostMapping("/api/articles")
+    public ResponseEntity<UploadResponse> uploadArticle(@Auth Long loginId,
+        @RequestBody @Valid UploadRequest request) {
+        final UploadResponse response = articleService.upload(loginId, request);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+}
+

--- a/src/main/java/real/world/domain/article/dto/request/UploadRequest.java
+++ b/src/main/java/real/world/domain/article/dto/request/UploadRequest.java
@@ -1,0 +1,25 @@
+package real.world.domain.article.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@JsonRootName(value = "article")
+@NoArgsConstructor
+public class UploadRequest {
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String description;
+
+    @NotBlank
+    private String body;
+
+    private List<String> tagList;
+
+}

--- a/src/main/java/real/world/domain/article/dto/request/UploadRequest.java
+++ b/src/main/java/real/world/domain/article/dto/request/UploadRequest.java
@@ -1,8 +1,9 @@
 package real.world.domain.article.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import jakarta.validation.constraints.NotBlank;
-import java.util.List;
+import java.util.Set;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,6 +21,7 @@ public class UploadRequest {
     @NotBlank
     private String body;
 
-    private List<String> tagList;
+    @JsonProperty("tagList")
+    private Set<String> tags;
 
 }

--- a/src/main/java/real/world/domain/article/dto/response/UploadResponse.java
+++ b/src/main/java/real/world/domain/article/dto/response/UploadResponse.java
@@ -1,0 +1,52 @@
+package real.world.domain.article.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import real.world.domain.article.entity.Article;
+import real.world.domain.user.dto.ProfileDto;
+
+@Getter
+@JsonRootName(value = "article")
+@NoArgsConstructor
+public class UploadResponse {
+
+    private String slug;
+    private String title;
+    private String description;
+    private String body;
+    private List<String> tagList;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private boolean favorited;
+    private int favoritesCount;
+
+    private ProfileDto author;
+
+    private UploadResponse(String slug, String title, String description, String body,
+        List<String> tagList, LocalDateTime createdAt, LocalDateTime updatedAt, boolean favorited,
+        int favoritesCount, ProfileDto author) {
+        this.slug = slug;
+        this.title = title;
+        this.description = description;
+        this.body = body;
+        this.tagList = tagList;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.favorited = favorited;
+        this.favoritesCount = favoritesCount;
+        this.author = author;
+    }
+
+    public static UploadResponse of(Article article) {
+        return new UploadResponse(
+            article.getSlug(), article.getTitle(), article.getDescription(),
+            article.getBody(), null, article.getCreatedAt(), article.getUpdatedAt(),
+            false, article.getFavoritesCount(), ProfileDto.of(article.getUser(), false)
+        );
+    }
+
+}

--- a/src/main/java/real/world/domain/article/dto/response/UploadResponse.java
+++ b/src/main/java/real/world/domain/article/dto/response/UploadResponse.java
@@ -1,6 +1,5 @@
 package real.world.domain.article.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -44,8 +43,9 @@ public class UploadResponse {
     public static UploadResponse of(Article article) {
         return new UploadResponse(
             article.getSlug(), article.getTitle(), article.getDescription(),
-            article.getBody(), null, article.getCreatedAt(), article.getUpdatedAt(),
-            false, article.getFavoritesCount(), ProfileDto.of(article.getUser(), false)
+            article.getBody(), article.getTagNames(), article.getCreatedAt(),
+            article.getUpdatedAt(), false, article.getFavoritesCount(),
+            ProfileDto.of(article.getUser(), false)
         );
     }
 

--- a/src/main/java/real/world/domain/article/entity/Article.java
+++ b/src/main/java/real/world/domain/article/entity/Article.java
@@ -1,6 +1,7 @@
 package real.world.domain.article.entity;
 
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -10,7 +11,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -34,6 +38,9 @@ public class Article {
     @Column(nullable = false, length = 50)
     private String title;
 
+    @Column(nullable = false, unique = true, length = 60)
+    private String slug;
+
     @Column(nullable = false)
     private String description;
 
@@ -48,13 +55,23 @@ public class Article {
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;
 
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
+    private List<Favorite> favorites;
+
     protected Article() {
     }
 
-    public Article(User user, String title, String description, String body) {
+    public Article(User user, String title, String slug, String description, String body) {
         this.user = user;
         this.title = title;
+        this.slug = slug;
         this.description = description;
         this.body = body;
+        this.favorites = Collections.emptyList();
     }
+
+    public int getFavoritesCount() {
+        return this.favorites.size();
+    }
+
 }

--- a/src/main/java/real/world/domain/article/entity/Article.java
+++ b/src/main/java/real/world/domain/article/entity/Article.java
@@ -15,6 +15,7 @@ import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -55,23 +56,42 @@ public class Article {
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;
 
-    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Favorite> favorites;
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TagArticle> tags;
 
     protected Article() {
     }
 
-    public Article(User user, String title, String slug, String description, String body) {
+    public Article(User user, String title, String slug, String description, String body,
+        List<Tag> tags) {
         this.user = user;
         this.title = title;
         this.slug = slug;
         this.description = description;
         this.body = body;
         this.favorites = Collections.emptyList();
+        setTags(tags);
     }
 
     public int getFavoritesCount() {
         return this.favorites.size();
+    }
+
+    public List<String> getTagNames() {
+        return this.tags.stream().map(
+            (tag) -> tag.getTag().getName()
+        ).collect(Collectors.toList());
+    }
+
+    private void setTags(List<Tag> tags) {
+        this.tags = tags.stream().map(this::convertTag).collect(Collectors.toList());
+    }
+
+    private TagArticle convertTag(Tag tag) {
+        return new TagArticle(this, tag);
     }
 
 }

--- a/src/main/java/real/world/domain/article/entity/Tag.java
+++ b/src/main/java/real/world/domain/article/entity/Tag.java
@@ -12,7 +12,6 @@ import lombok.Getter;
 @Entity(name = "tags")
 public class Tag {
 
-
     @Id
     @Column(name = "tag_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/real/world/domain/article/entity/TagArticle.java
+++ b/src/main/java/real/world/domain/article/entity/TagArticle.java
@@ -6,7 +6,9 @@ import jakarta.persistence.IdClass;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.io.Serializable;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity(name = "tag_articles")
@@ -31,11 +33,12 @@ public class TagArticle {
         this.tag = tag;
     }
 
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     static class TagArticleId implements Serializable {
 
-        private final Long article;
+        private Long article;
 
-        private final Long tag;
+        private Long tag;
 
         public TagArticleId(Long article, Long tag) {
             this.article = article;

--- a/src/main/java/real/world/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/real/world/domain/article/repository/ArticleRepository.java
@@ -1,0 +1,13 @@
+package real.world.domain.article.repository;
+
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
+import real.world.domain.article.entity.Article;
+
+public interface ArticleRepository extends Repository<Article, Long> {
+
+    Article save(Article article);
+
+    Optional<Article> findById(Long id);
+
+}

--- a/src/main/java/real/world/domain/article/repository/TagRepository.java
+++ b/src/main/java/real/world/domain/article/repository/TagRepository.java
@@ -1,0 +1,19 @@
+package real.world.domain.article.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.data.repository.Repository;
+import real.world.domain.article.entity.Tag;
+
+public interface TagRepository extends Repository<Tag, Long> {
+
+    Tag save(Tag tag);
+
+    Optional<Tag> findById(Long id);
+
+    Optional<Tag> findByName(String name);
+
+    List<Tag> findByNameIn(Set<String> names);
+
+}

--- a/src/main/java/real/world/domain/article/service/ArticleService.java
+++ b/src/main/java/real/world/domain/article/service/ArticleService.java
@@ -17,7 +17,6 @@ import real.world.error.exception.UserIdNotExistException;
 @Service
 public class ArticleService {
 
-
     private final UserRepository userRepository;
 
     private final ArticleRepository articleRepository;

--- a/src/main/java/real/world/domain/article/service/ArticleService.java
+++ b/src/main/java/real/world/domain/article/service/ArticleService.java
@@ -1,0 +1,49 @@
+package real.world.domain.article.service;
+
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+import real.world.domain.article.repository.ArticleRepository;
+import real.world.domain.article.dto.request.UploadRequest;
+import real.world.domain.article.dto.response.UploadResponse;
+import real.world.domain.article.entity.Article;
+import real.world.domain.user.entity.User;
+import real.world.domain.user.repository.UserRepository;
+import real.world.error.exception.UserIdNotExistException;
+
+@Service
+public class ArticleService {
+
+
+    private final UserRepository userRepository;
+
+    private final ArticleRepository articleRepository;
+
+    private final SlugTranslator slugTranslator;
+
+    public ArticleService(UserRepository userRepository, ArticleRepository articleRepository,
+        SlugTranslator slugTranslator) {
+        this.userRepository = userRepository;
+        this.articleRepository = articleRepository;
+        this.slugTranslator = slugTranslator;
+    }
+
+    @Transactional
+    public UploadResponse upload(Long loginId, UploadRequest request) {
+        final User user = userRepository.findById(loginId)
+            .orElseThrow(UserIdNotExistException::new);
+        final Article article = requestToEntity(user, request);
+        articleRepository.save(article);
+        return UploadResponse.of(article);
+    }
+
+    private Article requestToEntity(User user, UploadRequest request) {
+        return new Article(
+            user,
+            request.getTitle(),
+            slugTranslator.translate(request.getTitle()),
+            request.getDescription(),
+            request.getBody()
+        );
+    }
+
+}

--- a/src/main/java/real/world/domain/article/service/ArticleService.java
+++ b/src/main/java/real/world/domain/article/service/ArticleService.java
@@ -1,11 +1,15 @@
 package real.world.domain.article.service;
 
 import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Set;
 import org.springframework.stereotype.Service;
+import real.world.domain.article.entity.Tag;
 import real.world.domain.article.repository.ArticleRepository;
 import real.world.domain.article.dto.request.UploadRequest;
 import real.world.domain.article.dto.response.UploadResponse;
 import real.world.domain.article.entity.Article;
+import real.world.domain.article.repository.TagRepository;
 import real.world.domain.user.entity.User;
 import real.world.domain.user.repository.UserRepository;
 import real.world.error.exception.UserIdNotExistException;
@@ -18,12 +22,15 @@ public class ArticleService {
 
     private final ArticleRepository articleRepository;
 
+    private final TagRepository tagRepository;
+
     private final SlugTranslator slugTranslator;
 
     public ArticleService(UserRepository userRepository, ArticleRepository articleRepository,
-        SlugTranslator slugTranslator) {
+        TagRepository tagRepository, SlugTranslator slugTranslator) {
         this.userRepository = userRepository;
         this.articleRepository = articleRepository;
+        this.tagRepository = tagRepository;
         this.slugTranslator = slugTranslator;
     }
 
@@ -31,18 +38,30 @@ public class ArticleService {
     public UploadResponse upload(Long loginId, UploadRequest request) {
         final User user = userRepository.findById(loginId)
             .orElseThrow(UserIdNotExistException::new);
+        checkAndCreateTag(request.getTags());
         final Article article = requestToEntity(user, request);
         articleRepository.save(article);
         return UploadResponse.of(article);
     }
 
+    private void checkAndCreateTag(Set<String> tagNames) {
+        for(String tagName: tagNames) {
+            if(tagRepository.findByName(tagName).isEmpty()) {
+                final Tag tag = new Tag(tagName);
+                tagRepository.save(tag);
+            }
+        }
+    }
+
     private Article requestToEntity(User user, UploadRequest request) {
+        final List<Tag> tags = tagRepository.findByNameIn(request.getTags());
         return new Article(
             user,
             request.getTitle(),
             slugTranslator.translate(request.getTitle()),
             request.getDescription(),
-            request.getBody()
+            request.getBody(),
+            tags
         );
     }
 

--- a/src/main/java/real/world/domain/article/service/SlugTranslator.java
+++ b/src/main/java/real/world/domain/article/service/SlugTranslator.java
@@ -1,0 +1,7 @@
+package real.world.domain.article.service;
+
+public interface SlugTranslator {
+
+    String translate(String title);
+
+}

--- a/src/main/java/real/world/domain/article/service/SlugUUIDTranslator.java
+++ b/src/main/java/real/world/domain/article/service/SlugUUIDTranslator.java
@@ -1,0 +1,14 @@
+package real.world.domain.article.service;
+
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SlugUUIDTranslator implements SlugTranslator {
+
+    public String translate(String title) {
+        final String suffix =  UUID.randomUUID().toString().substring(0, 6);
+        return title.toLowerCase().replace("\\s+", "-") + "-" + suffix;
+    }
+
+}

--- a/src/main/java/real/world/domain/user/dto/ProfileDto.java
+++ b/src/main/java/real/world/domain/user/dto/ProfileDto.java
@@ -1,0 +1,30 @@
+package real.world.domain.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import real.world.domain.user.entity.User;
+
+@Getter
+@NoArgsConstructor
+public class ProfileDto {
+
+    private String username;
+
+    private String bio;
+
+    private String image;
+
+    private boolean following;
+
+    private ProfileDto(String username, String bio, String image, boolean following) {
+        this.username = username;
+        this.bio = bio;
+        this.image = image;
+        this.following = following;
+    }
+
+    public static ProfileDto of(User user, boolean following) {
+        return new ProfileDto(user.getUsername(), user.getBio(), user.getImageUrl(), following);
+    }
+
+}

--- a/src/main/resources/application-web-local.yml
+++ b/src/main/resources/application-web-local.yml
@@ -20,9 +20,8 @@ spring:
     serialization:
       wrap-root-value: true
 
-
 springdoc:
-  default-consumes-media-type: application/json;charset=UTF-8
-  default-produces-media-type: application/json;charset=UTF-8
+  default-consumes-media-type: application/yaml;charset=UTF-8
+  default-produces-media-type: application/yaml;charset=UTF-8
   swagger-ui:
-    url: /docs/open-api.json
+    url: /docs/open-api.yaml

--- a/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
+++ b/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
@@ -3,8 +3,6 @@ package real.world.domain.article.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -23,7 +21,6 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -73,14 +70,11 @@ public class ArticleControllerTest {
             // when
             final ResultActions resultActions = mockmvc.perform(
                 post("/api/articles").contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer token")
                     .content(objectMapper.writeValueAsString(request)));
 
             // then
             resultActions.andExpect(status().isCreated())
-                .andDo(document("upload",
-                    requestHeaders(headerWithName("Authorization").description(
-                        "Bearer token"))))
+                .andDo(document("upload"))
                 .andDo(print());
             verify(articleService).upload(any(), any());
         }

--- a/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
+++ b/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
@@ -72,7 +72,7 @@ public class ArticleControllerTest {
 
             // when
             final ResultActions resultActions = mockmvc.perform(
-                post("/articles").contentType(MediaType.APPLICATION_JSON)
+                post("/api/articles").contentType(MediaType.APPLICATION_JSON)
                     .header(HttpHeaders.AUTHORIZATION, "Bearer token")
                     .content(objectMapper.writeValueAsString(request)));
 

--- a/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
+++ b/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
@@ -1,0 +1,90 @@
+package real.world.domain.article.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static real.world.fixture.ArticleFixtures.태그_없는_게시물;
+import static real.world.fixture.UserFixtures.JOHN;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import jakarta.annotation.PostConstruct;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import real.world.config.WebMvcConfig;
+import real.world.domain.article.dto.request.UploadRequest;
+import real.world.domain.article.dto.response.UploadResponse;
+import real.world.domain.article.entity.Article;
+import real.world.domain.article.service.ArticleService;
+import real.world.domain.user.entity.User;
+import real.world.support.TestSecurityConfig;
+import real.world.support.WithMockUserId;
+import real.world.support.WithMockUserIdFactory;
+
+@WebMvcTest(controllers = {ArticleController.class})
+@Import({TestSecurityConfig.class, WebMvcConfig.class, WithMockUserIdFactory.class})
+@AutoConfigureRestDocs
+@ExtendWith({RestDocumentationExtension.class})
+public class ArticleControllerTest {
+
+    @MockBean
+    private ArticleService articleService;
+
+    @Autowired
+    private MockMvc mockmvc;
+
+    private ObjectMapper objectMapper;
+
+    @PostConstruct
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.enable(SerializationFeature.WRAP_ROOT_VALUE);
+    }
+
+    @Nested
+    class 게시물업로드 {
+
+        @Test
+        @WithMockUserId(user = JOHN)
+        void 상태코드200_으로_성공() throws Exception {
+            // given
+            final User user = JOHN.생성();
+            final Article article = 태그_없는_게시물.생성(user);
+            final UploadRequest request = 태그_없는_게시물.업로드를_한다();
+            given(articleService.upload(any(), any())).willReturn(UploadResponse.of(article));
+
+            // when
+            final ResultActions resultActions = mockmvc.perform(
+                post("/articles").contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer token")
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // then
+            resultActions.andExpect(status().isCreated())
+                .andDo(document("upload",
+                    requestHeaders(headerWithName("Authorization").description(
+                        "Bearer token"))))
+                .andDo(print());
+            verify(articleService).upload(any(), any());
+        }
+
+    }
+
+}

--- a/src/test/java/real/world/fixture/ArticleFixtures.java
+++ b/src/test/java/real/world/fixture/ArticleFixtures.java
@@ -1,0 +1,53 @@
+package real.world.fixture;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.test.util.ReflectionTestUtils;
+import real.world.domain.article.dto.request.UploadRequest;
+import real.world.domain.article.entity.Article;
+import real.world.domain.user.entity.User;
+
+@Getter
+public enum ArticleFixtures {
+
+    태그_없는_게시물("title", "slug", "desc", "body", null);
+
+    private final String title;
+
+    private final String slug;
+
+    private final String description;
+
+    private final String body;
+
+    private final List<String> tagList;
+
+    ArticleFixtures(String title, String slug, String description, String body, List<String> tagList) {
+        this.title = title;
+        this.slug = slug;
+        this.description = description;
+        this.body = body;
+        this.tagList = tagList;
+    }
+
+    public Article 생성(User user) {
+        return new Article(
+            user,
+            this.title,
+            this.slug,
+            this.description,
+            this.body
+        );
+    }
+
+    public UploadRequest 업로드를_한다() {
+        final  UploadRequest request = new UploadRequest();
+        ReflectionTestUtils.setField(request, "title", this.title);
+        ReflectionTestUtils.setField(request, "description", this.description);
+        ReflectionTestUtils.setField(request, "body", this.body);
+        ReflectionTestUtils.setField(request, "tagList", this.tagList);
+        return request;
+    }
+
+}

--- a/src/test/java/real/world/fixture/ArticleFixtures.java
+++ b/src/test/java/real/world/fixture/ArticleFixtures.java
@@ -1,17 +1,20 @@
 package real.world.fixture;
 
 import jakarta.validation.constraints.NotBlank;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import lombok.Getter;
 import org.springframework.test.util.ReflectionTestUtils;
 import real.world.domain.article.dto.request.UploadRequest;
 import real.world.domain.article.entity.Article;
+import real.world.domain.article.entity.Tag;
 import real.world.domain.user.entity.User;
 
 @Getter
 public enum ArticleFixtures {
 
-    태그_없는_게시물("title", "slug", "desc", "body", null);
+    태그_없는_게시물("title", "slug", "desc", "body", Collections.emptyList());
 
     private final String title;
 
@@ -21,9 +24,9 @@ public enum ArticleFixtures {
 
     private final String body;
 
-    private final List<String> tagList;
+    private final List<Tag> tagList;
 
-    ArticleFixtures(String title, String slug, String description, String body, List<String> tagList) {
+    ArticleFixtures(String title, String slug, String description, String body, List<Tag> tagList) {
         this.title = title;
         this.slug = slug;
         this.description = description;
@@ -37,7 +40,8 @@ public enum ArticleFixtures {
             this.title,
             this.slug,
             this.description,
-            this.body
+            this.body,
+            this.tagList
         );
     }
 
@@ -46,7 +50,7 @@ public enum ArticleFixtures {
         ReflectionTestUtils.setField(request, "title", this.title);
         ReflectionTestUtils.setField(request, "description", this.description);
         ReflectionTestUtils.setField(request, "body", this.body);
-        ReflectionTestUtils.setField(request, "tagList", this.tagList);
+        ReflectionTestUtils.setField(request, "tags", Set.copyOf(this.tagList));
         return request;
     }
 


### PR DESCRIPTION
##  📣요약
- `openapi3` - yaml로 변경
- `http` 파일 작성
- 아티클 업로드 구현
## ✨ 세부 내용
### `openapi3`
- 일단 `yaml`로 변경
- `openapi`랑 `restdocs`를 연동하는 툴이 자료가 너무 없어서 그냥 사용하지 말까 고민중
  - 임시로 `http` 파일을 작성해봄
### 아티클 업로드 구현
- `SlugTranslator`를 추상화하여 인터페이스로 분리하였음
- 