### PR TITLE
[Chore] Swagger 제거, Querydsl 추가, /api 처리

### DIFF
--- a/.idea/httpRequests/http-requests-log.http
+++ b/.idea/httpRequests/http-requests-log.http
@@ -1,0 +1,884 @@
+POST http://localhost:8080/api/users
+Content-Type: application/json
+Content-Length: 100
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "username": "username",
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-19T003808.422.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-19T003806.201.json
+
+###
+
+POST http://localhost:8080/api/users
+Content-Type: application/json
+Content-Length: 100
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "username": "username",
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-19T003802.201.json
+
+###
+
+POST http://localhost:8080/api/users
+Content-Type: application/json
+Content-Length: 100
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "username": "username",
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-19T003353.201.json
+
+###
+
+POST http://localhost:8080/api/users
+Content-Type: application/json
+Content-Length: 100
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "username": "username",
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-19T003241.200.txt
+
+###
+
+GET http://localhost:8080/api/profiles
+Authorization: BEARER eyJhbGciOiJIUzUxMiJ9.eyJwcmluY2lwYWwiOiIxIiwicm9sZSI6IlJPTEVfVVNFUiIsImV4cCI6MTY5NzYyMzY0OH0.ESX_kX5xTEbgdoGaFXRoAH3h6maGCoqpL5VjT77GqMqNKUmkBn9_JpDacFydqlQKZ7vjvAK2WDGmIx-4ZS7WMQ
+Content-Type: application/json
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+<> 2023-09-18T190755.201.txt
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-18T190728.201.json
+
+###
+
+POST http://localhost:8080/api/users
+Content-Type: application/json
+Content-Length: 100
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "username": "username",
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-18T190656.422.json
+
+###
+
+POST http://localhost:8080/api/users
+Content-Type: application/json
+Content-Length: 100
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "username": "username",
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-18T190643.201.json
+
+###
+
+POST http://localhost:8080/api/articles
+Authorization: BEARER eyJhbGciOiJIUzUxMiJ9.eyJwcmluY2lwYWwiOiIxIiwicm9sZSI6IlJPTEVfVVNFUiIsImV4cCI6MTY5NzYxMzE3NX0.oEFTgkd9X-JUMx7E58uQZpRcIINvRpaFQ4QAI2ZJbJGbElghwCWVVxMCTX74qpeur-c2J-zpLm6iAAQzwaZ-IQ
+Content-Type: application/json
+Content-Length: 141
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "article": {
+    "title": "title",
+    "description": "desc",
+    "body": "body",
+    "tagList": [
+      "tag1",
+      "tag2"
+    ]
+  }
+}
+
+<> 2023-09-18T161317.201.json
+
+###
+
+POST http://localhost:8080/api/articles
+Authorization: BEARER eyJhbGciOiJIUzUxMiJ9.eyJwcmluY2lwYWwiOiIxIiwicm9sZSI6IlJPTEVfVVNFUiIsImV4cCI6MTY5NzYxMzE3NX0.oEFTgkd9X-JUMx7E58uQZpRcIINvRpaFQ4QAI2ZJbJGbElghwCWVVxMCTX74qpeur-c2J-zpLm6iAAQzwaZ-IQ
+Content-Type: application/json
+Content-Length: 141
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "article": {
+    "title": "title",
+    "description": "desc",
+    "body": "body",
+    "tagList": [
+      "tag1",
+      "tag2"
+    ]
+  }
+}
+
+<> 2023-09-18T161257.201.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-18T161255.201.json
+
+###
+
+POST http://localhost:8080/api/users
+Content-Type: application/json
+Content-Length: 100
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "username": "username",
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-18T161252.201.json
+
+###
+
+POST http://localhost:8080/api/articles
+Authorization: BEARER eyJhbGciOiJIUzUxMiJ9.eyJwcmluY2lwYWwiOiIxIiwicm9sZSI6IlJPTEVfVVNFUiIsImV4cCI6MTY5NzYxMjYzMX0.ZQ8HS0fHrcigwlSLJOmCAkuZMJXjA9-_mWfLYfH87Ev7nRc7jfzzczufx0AsOpFIXUeRCc75Jy21vXdPsuTwGg
+Content-Type: application/json
+Content-Length: 141
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "article": {
+    "title": "title",
+    "description": "desc",
+    "body": "body",
+    "tagList": [
+      "tag1",
+      "tag2"
+    ]
+  }
+}
+
+<> 2023-09-18T160409.422.json
+
+###
+
+POST http://localhost:8080/api/articles
+Authorization: BEARER eyJhbGciOiJIUzUxMiJ9.eyJwcmluY2lwYWwiOiIxIiwicm9sZSI6IlJPTEVfVVNFUiIsImV4cCI6MTY5NzYxMjYzMX0.ZQ8HS0fHrcigwlSLJOmCAkuZMJXjA9-_mWfLYfH87Ev7nRc7jfzzczufx0AsOpFIXUeRCc75Jy21vXdPsuTwGg
+Content-Type: application/json
+Content-Length: 141
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "article": {
+    "title": "title",
+    "description": "desc",
+    "body": "body",
+    "tagList": [
+      "tag1",
+      "tag2"
+    ]
+  }
+}
+
+<> 2023-09-18T160355.422.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-18T160351.201.json
+
+###
+
+POST http://localhost:8080/api/users
+Content-Type: application/json
+Content-Length: 100
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "username": "username",
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-18T160349.201.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-18T160125.201.json
+
+###
+
+POST http://localhost:8080/api/users
+Content-Type: application/json
+Content-Length: 100
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "username": "username",
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-18T160121.201.json
+
+###
+
+POST http://localhost:8080/api/articles
+Authorization: BEARER eyJhbGciOiJIUzUxMiJ9.eyJwcmluY2lwYWwiOiIxIiwicm9sZSI6IlJPTEVfVVNFUiIsImV4cCI6MTY5NzYxMjMzOH0.n0FPsfltIUfBu3_dPo4T4YXuLTSNaC2N8OAd6ap-LgofHHshGC-7mrUIn0kfWpz12JOrKmDrvOJwzEg3J5F8EA
+Content-Type: application/json
+Content-Length: 138
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "article": {
+    "title": "title",
+    "description": "desc",
+    "body": "body",
+    "tags": [
+      "tag1",
+      "tag2"
+    ]
+  }
+}
+
+<> 2023-09-18T155921.422.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-18T155858.201.json
+
+###
+
+POST http://localhost:8080/api/users
+Content-Type: application/json
+Content-Length: 100
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "username": "username",
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-18T155855.201.json
+
+###
+
+POST http://localhost:8080/api/articles
+Authorization: BEARER eyJhbGciOiJIUzUxMiJ9.eyJwcmluY2lwYWwiOiIxIiwicm9sZSI6IlJPTEVfVVNFUiIsImV4cCI6MTY5NzUzNzk2Mn0.KNivpHuoBcBSPsrCIZ9ys17Fm7DlnAZPJTFS0PrWb1BkYSoHW5ASboZT28hDN4x37gAzHkSHdycHi5rchrASUQ
+Content-Type: application/json
+Content-Length: 90
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "article": {
+    "title": "title",
+    "description": "desc",
+    "body": "body"
+  }
+}
+
+<> 2023-09-17T191924.201.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T191922.201.json
+
+###
+
+POST http://localhost:8080/api/users
+Content-Type: application/json
+Content-Length: 100
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "username": "username",
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T191921.201.json
+
+###
+
+POST http://localhost:8080/api/articles
+Authorization: BEARER eyJhbGciOiJIUzUxMiJ9.eyJwcmluY2lwYWwiOiIxIiwicm9sZSI6IlJPTEVfVVNFUiIsImV4cCI6MTY5NzUzNzE1Nn0.Pkyz5xAQTumGlDxZ7EDXjwo8LzveM-l5PS7J6jqUABXCLbt1vMRkVXy-tfyNvgU7Yqh0wkIbjDAVaZieh96PkQ
+Content-Type: application/json
+Content-Length: 90
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "article": {
+    "title": "title",
+    "description": "desc",
+    "body": "body"
+  }
+}
+
+<> 2023-09-17T191059.404.json
+
+###
+
+POST http://localhost:8080/api/profiles
+Authorization: BEARER eyJhbGciOiJIUzUxMiJ9.eyJwcmluY2lwYWwiOiIxIiwicm9sZSI6IlJPTEVfVVNFUiIsImV4cCI6MTY5NzUzNzE1Nn0.Pkyz5xAQTumGlDxZ7EDXjwo8LzveM-l5PS7J6jqUABXCLbt1vMRkVXy-tfyNvgU7Yqh0wkIbjDAVaZieh96PkQ
+Content-Type: application/json
+Content-Length: 90
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "article": {
+    "title": "title",
+    "description": "desc",
+    "body": "body"
+  }
+}
+
+<> 2023-09-17T191014.422.json
+
+###
+
+GET http://localhost:8080/api/profiles
+Authorization: BEARER eyJhbGciOiJIUzUxMiJ9.eyJwcmluY2lwYWwiOiIxIiwicm9sZSI6IlJPTEVfVVNFUiIsImV4cCI6MTY5NzUzNzE1Nn0.Pkyz5xAQTumGlDxZ7EDXjwo8LzveM-l5PS7J6jqUABXCLbt1vMRkVXy-tfyNvgU7Yqh0wkIbjDAVaZieh96PkQ
+Content-Type: application/json
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+<> 2023-09-17T190708.201.txt
+
+###
+
+GET http://localhost:8080/api/profiles
+Authorization: BEARER eyJhbGciOiJIUzUxMiJ9.eyJwcmluY2lwYWwiOiIxIiwicm9sZSI6IlJPTEVfVVNFUiIsImV4cCI6MTY5NzUzNzE1Nn0.Pkyz5xAQTumGlDxZ7EDXjwo8LzveM-l5PS7J6jqUABXCLbt1vMRkVXy-tfyNvgU7Yqh0wkIbjDAVaZieh96PkQ
+Content-Type: application/json
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+<> 2023-09-17T190624.201.txt
+
+###
+
+GET http://localhost:8080/api/profiles
+Authorization: Bearer BEARER eyJhbGciOiJIUzUxMiJ9.eyJwcmluY2lwYWwiOiIxIiwicm9sZSI6IlJPTEVfVVNFUiIsImV4cCI6MTY5NzUzNzE1Nn0.Pkyz5xAQTumGlDxZ7EDXjwo8LzveM-l5PS7J6jqUABXCLbt1vMRkVXy-tfyNvgU7Yqh0wkIbjDAVaZieh96PkQ
+Content-Type: application/json
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+<> 2023-09-17T190605.200.txt
+
+###
+
+GET http://localhost:8080/api/profiles
+Authorization: Bearer BEARER eyJhbGciOiJIUzUxMiJ9.eyJwcmluY2lwYWwiOiIxIiwicm9sZSI6IlJPTEVfVVNFUiIsImV4cCI6MTY5NzUzNzE1Nn0.Pkyz5xAQTumGlDxZ7EDXjwo8LzveM-l5PS7J6jqUABXCLbt1vMRkVXy-tfyNvgU7Yqh0wkIbjDAVaZieh96PkQ
+Content-Type: application/json
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+<> 2023-09-17T190601.200.txt
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T190556.201.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T190554.201.json
+
+###
+
+GET http://localhost:8080/api/profiles
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJwcmluY2lwYWwiOiIxIiwicm9sZSI6IlJPTEVfVVNFUiIsImV4cCI6MTY5NzUzNzEwMH0.cBYcp69itGEo7tPMZ3_rqBhnSLqlBtwWfhCCDL940guFF4WMVMQ5k5Eex8TJK_g0-J5-9Wm6eU8_fgSf-JZzig
+Content-Type: application/json
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+<> 2023-09-17T190526.200.txt
+
+###
+
+GET http://localhost:8080/api/profiles
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJwcmluY2lwYWwiOiIxIiwicm9sZSI6IlJPTEVfVVNFUiIsImV4cCI6MTY5NzUzNzEwMH0.cBYcp69itGEo7tPMZ3_rqBhnSLqlBtwWfhCCDL940guFF4WMVMQ5k5Eex8TJK_g0-J5-9Wm6eU8_fgSf-JZzig
+Content-Type: application/json
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+<> 2023-09-17T190518.200.txt
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T190500.201.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T190434.201.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T190430.201.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T190301.201.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T190030.201.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T185956.201.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T185922.201.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T185833.201.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T185804.201.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T185632.201.json
+
+###
+
+GET http://localhost:8080/api/profiles
+Authorization: Bearer null
+Content-Type: application/json
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+<> 2023-09-17T185615.200.txt
+
+###
+
+GET http://localhost:8080/api/profiles
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+<> 2023-09-17T185547.200.txt
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T185452.201.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T185447.201.json
+
+###
+
+POST http://localhost:8080/api/users/login
+Content-Type: application/json
+Content-Length: 72
+Connection: Keep-Alive
+User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.8)
+Accept-Encoding: br,deflate,gzip,x-gzip
+
+{
+  "user": {
+    "email": "eee@email.com",
+    "password": "1234"
+  }
+}
+
+<> 2023-09-17T185436.201.json
+
+###
+

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,12 @@ dependencies {
 
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:3.1.4'
 
+	// Querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
+
 	compileOnly 'org.projectlombok:lombok:1.18.28'
 	annotationProcessor 'org.projectlombok:lombok:1.18.28'
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,6 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.2'
 	id 'io.spring.dependency-management' version '1.1.2'
-
-
-	// restdocs + swagger
-	id 'com.epages.restdocs-api-spec' version '0.18.2'
-	id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 group = 'real'
@@ -39,11 +34,8 @@ dependencies {
 
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:3.1.4'
 
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
-
 	compileOnly 'org.projectlombok:lombok:1.18.28'
 	annotationProcessor 'org.projectlombok:lombok:1.18.28'
-
 
 	// Test Dependencies
 	testCompileOnly 'org.projectlombok:lombok:1.18.28'
@@ -53,36 +45,8 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test:6.1.2'
 	testImplementation 'io.rest-assured:rest-assured:5.3.1'
 	testImplementation 'com.h2database:h2:2.2.220'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:3.0.0'
-	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.18.2'
 }
 
 test {
 	useJUnitPlatform()
 }
-
-tasks.withType(GenerateSwaggerUI).configureEach {
-	dependsOn 'openapi3'
-
-	delete file('src/main/resources/static/docs/')
-	copy {
-		from "build/docs/"
-		into "src/main/resources/static/docs/"
-	}
-}
-
-bootJar{
-	dependsOn(':openapi3')
-}
-
-openapi3 {
-	server = "http://localhost:8080"
-	title = "Swagger API Docs"
-	description = "Spring REST Docs with SwaggerUI."
-	version = "0.0.1"
-	outputFileNamePrefix = 'open-api'
-	format = 'yaml'
-
-	outputDirectory = 'build/docs'
-}
-

--- a/src/main/java/real/world/config/SecurityConfig.java
+++ b/src/main/java/real/world/config/SecurityConfig.java
@@ -34,8 +34,8 @@ import real.world.security.support.NorRequestMatcher;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private static final String LOGIN_PATH = "/api/users/login";
-    private static final String[] AUTH_PATH = {"/api/users", LOGIN_PATH};
+    private static final String LOGIN_PATH = "/users/login";
+    private static final String[] AUTH_PATH = {"/users", LOGIN_PATH};
     private static final String[] SWAGGER_PATH = {"/docs/open-api.json", "/swagger-ui/**",
         "/v3/**"};
 

--- a/src/main/java/real/world/domain/article/controller/ArticleController.java
+++ b/src/main/java/real/world/domain/article/controller/ArticleController.java
@@ -20,7 +20,7 @@ public class ArticleController {
         this.articleService = articleService;
     }
 
-    @PostMapping("/api/articles")
+    @PostMapping("/articles")
     public ResponseEntity<UploadResponse> uploadArticle(@Auth Long loginId,
         @RequestBody @Valid UploadRequest request) {
         final UploadResponse response = articleService.upload(loginId, request);

--- a/src/main/java/real/world/domain/user/controller/UserController.java
+++ b/src/main/java/real/world/domain/user/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
         this.userService = userService;
     }
 
-    @PostMapping("/api/users")
+    @PostMapping("/users")
     public ResponseEntity<UserResponse> register(
         @RequestBody @Valid RegisterRequest registerRequest) {
         final UserResponse response = userService.register(registerRequest);
@@ -43,7 +43,7 @@ public class UserController {
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
-    @PostMapping("/api/users/login")
+    @PostMapping("/users/login")
     public ResponseEntity<UserResponse> login(Authentication authentication, HttpServletResponse httpServletResponse) {
         final String id = authentication.getPrincipal().toString();
         final UserResponse response = userService.getUser(Long.valueOf(id));
@@ -57,20 +57,20 @@ public class UserController {
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
-    @GetMapping("/api/user")
+    @GetMapping("/user")
     public ResponseEntity<UserResponse> currentUser(@Auth Long loginId) {
         final UserResponse response = userService.getUser(loginId);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
-    @PutMapping("/api/user")
+    @PutMapping("/user")
     public ResponseEntity<UserResponse> update(@Auth Long loginId,
         @RequestBody UpdateRequest updateRequest) {
         final UserResponse response = userService.update(loginId, updateRequest);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
-    @GetMapping("/api/profiles")
+    @GetMapping("/profiles")
     public ResponseEntity<String> checkAuth(@Auth Long loginId) {
         return new ResponseEntity<>("ok", HttpStatus.CREATED);
     }

--- a/src/main/resources/application-web-local.yml
+++ b/src/main/resources/application-web-local.yml
@@ -4,6 +4,8 @@ logging:
 
 server:
   port: 8080
+  servlet:
+    context-path: /api
 
 base:
   bio: Hello!

--- a/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
+++ b/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
@@ -69,7 +69,7 @@ public class ArticleControllerTest {
 
             // when
             final ResultActions resultActions = mockmvc.perform(
-                post("/api/articles").contentType(MediaType.APPLICATION_JSON)
+                post("/articles").contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)));
 
             // then

--- a/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
+++ b/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
@@ -3,8 +3,7 @@ package real.world.domain.article.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static real.world.fixture.ArticleFixtures.태그_없는_게시물;
@@ -15,14 +14,11 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import jakarta.annotation.PostConstruct;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import real.world.config.WebMvcConfig;
@@ -37,8 +33,6 @@ import real.world.support.WithMockUserIdFactory;
 
 @WebMvcTest(controllers = {ArticleController.class})
 @Import({TestSecurityConfig.class, WebMvcConfig.class, WithMockUserIdFactory.class})
-@AutoConfigureRestDocs
-@ExtendWith({RestDocumentationExtension.class})
 public class ArticleControllerTest {
 
     @MockBean
@@ -74,7 +68,6 @@ public class ArticleControllerTest {
 
             // then
             resultActions.andExpect(status().isCreated())
-                .andDo(document("upload"))
                 .andDo(print());
             verify(articleService).upload(any(), any());
         }

--- a/src/test/java/real/world/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/real/world/domain/user/controller/UserControllerTest.java
@@ -76,7 +76,7 @@ public class UserControllerTest {
 
             // when
             final ResultActions resultActions = mockmvc.perform(
-                post("/api/users").contentType(MediaType.APPLICATION_JSON)
+                post("/users").contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)));
 
             // then
@@ -94,7 +94,7 @@ public class UserControllerTest {
 
             // when
             final ResultActions resultActions = mockmvc.perform(
-                post("/api/users").contentType(MediaType.APPLICATION_JSON)
+                post("/users").contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)));
 
             // then
@@ -116,7 +116,7 @@ public class UserControllerTest {
             given(userService.getUser(id)).willReturn(UserResponse.of(user));
 
             // when
-            final ResultActions resultActions = mockmvc.perform(get("/api/user"));
+            final ResultActions resultActions = mockmvc.perform(get("/user"));
 
             // then
             resultActions.andExpect(status().isCreated())
@@ -132,7 +132,7 @@ public class UserControllerTest {
             given(userService.getUser(any())).willThrow(new UserIdNotExistException());
 
             // when
-            final ResultActions resultActions = mockmvc.perform(get("/api/user"));
+            final ResultActions resultActions = mockmvc.perform(get("/user"));
 
             // then
             resultActions.andExpect(status().isUnprocessableEntity())
@@ -152,7 +152,7 @@ public class UserControllerTest {
             given(userService.update(anyLong(), any(UpdateRequest.class))).willReturn(new UserResponse());
 
             // when
-            final ResultActions resultActions = mockmvc.perform(put("/api/user")
+            final ResultActions resultActions = mockmvc.perform(put("/user")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(new UpdateRequest())));
 
@@ -170,7 +170,7 @@ public class UserControllerTest {
             given(userService.update(anyLong(), any(UpdateRequest.class))).willThrow(new UserIdNotExistException());
 
             // when
-            final ResultActions resultActions = mockmvc.perform(put("/api/user")
+            final ResultActions resultActions = mockmvc.perform(put("/user")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(new UpdateRequest())));
 
@@ -191,7 +191,7 @@ public class UserControllerTest {
         void 상태코드_200으로_성공() throws Exception {
             // given & when
             final ResultActions resultActions = mockmvc.perform(
-                get("/api/profiles"));
+                get("/profiles"));
 
             // then
             resultActions.andExpect(status().isCreated())

--- a/src/test/java/real/world/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/real/world/domain/user/controller/UserControllerTest.java
@@ -1,14 +1,12 @@
 package real.world.domain.user.controller;
 
-import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static real.world.fixture.UserFixtures.JOHN;
@@ -18,14 +16,11 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import jakarta.annotation.PostConstruct;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import real.world.config.WebMvcConfig;
@@ -43,8 +38,6 @@ import real.world.support.WithMockUserIdFactory;
 
 @WebMvcTest(controllers = {UserController.class})
 @Import({TestSecurityConfig.class, WebMvcConfig.class, WithMockUserIdFactory.class})
-@AutoConfigureRestDocs
-@ExtendWith({RestDocumentationExtension.class})
 public class UserControllerTest {
 
     @MockBean
@@ -81,7 +74,6 @@ public class UserControllerTest {
 
             // then
             resultActions.andExpect(status().isCreated())
-                .andDo(document("register"))
                 .andDo(print());
             verify(userService).register(any());
         }
@@ -120,7 +112,6 @@ public class UserControllerTest {
 
             // then
             resultActions.andExpect(status().isCreated())
-                .andDo(document("getUser"))
                 .andDo(print());
             verify(userService).getUser(any());
         }
@@ -149,7 +140,8 @@ public class UserControllerTest {
         @WithMockUserId(user = JOHN)
         void 상태코드_200으로_성공() throws Exception {
             // given
-            given(userService.update(anyLong(), any(UpdateRequest.class))).willReturn(new UserResponse());
+            given(userService.update(anyLong(), any(UpdateRequest.class))).willReturn(
+                new UserResponse());
 
             // when
             final ResultActions resultActions = mockmvc.perform(put("/user")
@@ -158,7 +150,6 @@ public class UserControllerTest {
 
             // then
             resultActions.andExpect(status().isCreated())
-                .andDo(document("update"))
                 .andDo(print());
             verify(userService).update(anyLong(), any(UpdateRequest.class));
         }
@@ -167,7 +158,8 @@ public class UserControllerTest {
         @WithMockUserId(user = JOHN)
         void UserID가_존재하지_않는다면_상태_422로_실패() throws Exception {
             // given
-            given(userService.update(anyLong(), any(UpdateRequest.class))).willThrow(new UserIdNotExistException());
+            given(userService.update(anyLong(), any(UpdateRequest.class))).willThrow(
+                new UserIdNotExistException());
 
             // when
             final ResultActions resultActions = mockmvc.perform(put("/user")
@@ -195,7 +187,6 @@ public class UserControllerTest {
 
             // then
             resultActions.andExpect(status().isCreated())
-                .andDo(document("profile"))
                 .andDo(print());
         }
 

--- a/src/test/java/real/world/e2e/UserE2ETest.java
+++ b/src/test/java/real/world/e2e/UserE2ETest.java
@@ -45,7 +45,7 @@ public class UserE2ETest {
         final RegisterRequest request = JOHN.회원가입을_한다();
 
         // when
-        final ExtractableResponse<Response> extractableResponse = POST_요청을_보낸다("/api/users",
+        final ExtractableResponse<Response> extractableResponse = POST_요청을_보낸다("/users",
             request);
         final UserResponse response = extractableResponse.as(UserResponse.class);
 

--- a/src/test/java/real/world/support/TestSecurityConfig.java
+++ b/src/test/java/real/world/support/TestSecurityConfig.java
@@ -17,9 +17,9 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class TestSecurityConfig {
 
-    private static final String LOGIN_PATH = "/api/users/login";
+    private static final String LOGIN_PATH = "/users/login";
 
-    private static final String[] AUTH_PATH = {"/api/users", LOGIN_PATH};
+    private static final String[] AUTH_PATH = {"/users", LOGIN_PATH};
 
     private static final String[] SWAGGER_PATH = {"/docs/open-api.json", "/swagger-ui/**",
         "/v3/**"};


### PR DESCRIPTION
##  📣요약
-
## ✨ 세부 내용
### Swagger 제거
- 의존성 제거 및 테스트에서도 제거
### Querydsl 추가
- (참고)다른 블로그 상에 있는 작성법은 최신화가 안되어있음
  - 업데이트로 플러그인 설치 및 기타 잡다한 설정 안해줘도 되는듯함. -> 인스타클론때도 플러그인을 사용했었는데 관련해서 잡다한 버그가 많았음.
- 네이밍은 `UserQuerydslRepository`와 `UserQuerydslRepositoryImpl`와 같이 사용할 예정
### `/api` 처리
- `/api`로 묶어내고 기존 `RequestMapping`에서 제거
- 관련하여 테스트 및 시큐리티 설정까지 수정