### PR TITLE
[Feature] 아티클 조회, 삭제, 수정 API 구현

### DIFF
--- a/http/article.http
+++ b/http/article.http
@@ -52,11 +52,32 @@ Content-Type: application/json
 }
 
 > {%
-  client.log(response.body.article.slug);
   client.global.set("slug", response.body.article.slug);
 %}
 
 ### 아티클 조회
 GET {{domain}}/api/articles/{{slug}}
+Authorization: {{access_token}}
+Content-Type: application/json
+
+### 아티클 수정
+PUT {{domain}}/api/articles/{{slug}}
+Authorization: {{access_token}}
+Content-Type: application/json
+
+{
+  "article": {
+    "title": "Updated Title",
+    "description": "updated desc",
+    "body": "updated body"
+  }
+}
+
+> {%
+  client.global.set("slug", response.body.article.slug);
+%}
+
+### 아티클 삭제
+DELETE {{domain}}/api/articles/{{slug}}
 Authorization: {{access_token}}
 Content-Type: application/json

--- a/http/article.http
+++ b/http/article.http
@@ -50,3 +50,13 @@ Content-Type: application/json
     ]
   }
 }
+
+> {%
+  client.log(response.body.article.slug);
+  client.global.set("slug", response.body.article.slug);
+%}
+
+### 아티클 조회
+GET {{domain}}/api/articles/{{slug}}
+Authorization: {{access_token}}
+Content-Type: application/json

--- a/src/main/java/real/world/config/SecurityConfig.java
+++ b/src/main/java/real/world/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
     private static final String[] AUTH_PATH = {"/users", LOGIN_PATH};
     private static final String[] SWAGGER_PATH = {"/docs/open-api.json", "/swagger-ui/**",
         "/v3/**"};
+    private static final String[]  OPTIONAL_PATH = {"/profiles/*"};
 
     private final ObjectPostProcessor<Object> objectPostProcessor;
 
@@ -56,6 +57,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.POST, AUTH_PATH).permitAll()
                 .requestMatchers(HttpMethod.GET, SWAGGER_PATH).permitAll()
+                .requestMatchers(HttpMethod.GET, OPTIONAL_PATH).hasAnyRole("USER", "ANONYMOUS")
                 .anyRequest().hasRole("USER")
             )
             .addFilterBefore(customAuthenticationFilter(),
@@ -112,7 +114,7 @@ public class SecurityConfig {
             .flatMap(Stream::of)
             .toArray(String[]::new);
         final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(
-            new NorRequestMatcher(norPath), authenticationManager());
+            new NorRequestMatcher(norPath), authenticationManager(), OPTIONAL_PATH);
         filter.setAuthenticationFailureHandler(customAuthenticationFailureHandler());
 
         return filter;

--- a/src/main/java/real/world/domain/article/controller/ArticleController.java
+++ b/src/main/java/real/world/domain/article/controller/ArticleController.java
@@ -3,6 +3,8 @@ package real.world.domain.article.controller;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,6 +32,13 @@ public class ArticleController {
         final Long articleId = articleService.upload(loginId, request);
         final ArticleResponse response = articleQueryService.getArticle(loginId, articleId);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/articles/{slug}")
+    public ResponseEntity<ArticleResponse> uploadArticle(@Auth Long loginId,
+        @PathVariable("slug") String slug) {
+        final ArticleResponse response = articleQueryService.getArticle(loginId, slug);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/real/world/domain/article/controller/ArticleController.java
+++ b/src/main/java/real/world/domain/article/controller/ArticleController.java
@@ -3,11 +3,14 @@ package real.world.domain.article.controller;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import real.world.domain.article.dto.request.ArticleUpdateRequest;
 import real.world.domain.article.dto.request.UploadRequest;
 import real.world.domain.article.dto.response.ArticleResponse;
 import real.world.domain.article.service.ArticleQueryService;
@@ -21,7 +24,8 @@ public class ArticleController {
 
     private final ArticleQueryService articleQueryService;
 
-    public ArticleController(ArticleService articleService, ArticleQueryService articleQueryService) {
+    public ArticleController(ArticleService articleService,
+        ArticleQueryService articleQueryService) {
         this.articleService = articleService;
         this.articleQueryService = articleQueryService;
     }
@@ -35,10 +39,25 @@ public class ArticleController {
     }
 
     @GetMapping("/articles/{slug}")
-    public ResponseEntity<ArticleResponse> uploadArticle(@Auth Long loginId,
+    public ResponseEntity<ArticleResponse> getArticle(@Auth Long loginId,
         @PathVariable("slug") String slug) {
         final ArticleResponse response = articleQueryService.getArticle(loginId, slug);
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/articles/{slug}")
+    public ResponseEntity<ArticleResponse> updateArticle(@Auth Long loginId,
+        @PathVariable("slug") String slug, @RequestBody @Valid ArticleUpdateRequest request) {
+        final Long articleId = articleService.update(loginId, slug, request);
+        final ArticleResponse response = articleQueryService.getArticle(loginId, articleId);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/articles/{slug}")
+    public ResponseEntity<Void> deleteArticle(@Auth Long loginId,
+        @PathVariable("slug") String slug) {
+        articleService.delete(loginId, slug);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
 }

--- a/src/main/java/real/world/domain/article/dto/request/ArticleUpdateRequest.java
+++ b/src/main/java/real/world/domain/article/dto/request/ArticleUpdateRequest.java
@@ -1,0 +1,22 @@
+package real.world.domain.article.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@JsonRootName(value = "article")
+@NoArgsConstructor
+public class ArticleUpdateRequest {
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String description;
+
+    @NotBlank
+    private String body;
+
+}

--- a/src/main/java/real/world/domain/article/entity/Article.java
+++ b/src/main/java/real/world/domain/article/entity/Article.java
@@ -78,7 +78,6 @@ public class Article {
     }
 
     public void update(Article article) {
-        verifyUserId(article.userId);
         this.title = article.title;
         this.description = article.description;
         this.body = article.body;

--- a/src/main/java/real/world/domain/article/entity/Article.java
+++ b/src/main/java/real/world/domain/article/entity/Article.java
@@ -1,7 +1,6 @@
 package real.world.domain.article.entity;
 
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -13,7 +12,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
@@ -60,16 +58,10 @@ public class Article {
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;
 
-    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Favorite> favorites;
-
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "article_tags", joinColumns = @JoinColumn(name = "article_id"))
     @Column(name = "name")
     private List<String> tags;
-
-    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Comment> comments;
 
     protected Article() {
     }
@@ -80,7 +72,6 @@ public class Article {
         this.title = title;
         this.description = description;
         this.body = body;
-        this.favorites = Collections.emptyList();
         this.tags = tags.stream().toList();
         setSlug(translator);
     }

--- a/src/main/java/real/world/domain/article/entity/Article.java
+++ b/src/main/java/real/world/domain/article/entity/Article.java
@@ -11,7 +11,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
@@ -21,7 +20,6 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import real.world.domain.article.service.SlugTranslator;
-import real.world.domain.user.entity.User;
 import real.world.error.exception.ArticleUnauthorizedException;
 
 @Getter
@@ -34,9 +32,8 @@ public class Article {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+    @Column(name = "user_id")
+    private Long userId;
 
     @Column(nullable = false, length = 50)
     private String title;
@@ -66,9 +63,9 @@ public class Article {
     protected Article() {
     }
 
-    public Article(User user, String title, SlugTranslator translator, String description,
+    public Article(Long userId, String title, SlugTranslator translator, String description,
         String body, Collection<String> tags) {
-        this.user = user;
+        this.userId = userId;
         this.title = title;
         this.description = description;
         this.body = body;
@@ -89,7 +86,7 @@ public class Article {
     }
 
     public void verifyUserId(Long userId) {
-        if (!userId.equals(this.user.getId())) {
+        if (!userId.equals(this.userId)) {
             throw new ArticleUnauthorizedException();
         }
     }

--- a/src/main/java/real/world/domain/article/entity/Article.java
+++ b/src/main/java/real/world/domain/article/entity/Article.java
@@ -32,7 +32,7 @@ public class Article {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "user_id")
+    @Column(name = "user_id", nullable = false)
     private Long userId;
 
     @Column(nullable = false, length = 50)
@@ -73,12 +73,12 @@ public class Article {
         setSlug(translator);
     }
 
-    public Article(String title, SlugTranslator translator, String description, String body) {
-        this(null, title, translator, description, body, Collections.emptyList());
+    public Article(Long userId, String title, SlugTranslator translator, String description, String body) {
+        this(userId, title, translator, description, body, Collections.emptyList());
     }
 
-    public void update(Long userId, Article article) {
-        verifyUserId(userId);
+    public void update(Article article) {
+        verifyUserId(article.userId);
         this.title = article.title;
         this.description = article.description;
         this.body = article.body;

--- a/src/main/java/real/world/domain/article/entity/Comment.java
+++ b/src/main/java/real/world/domain/article/entity/Comment.java
@@ -14,7 +14,6 @@ import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import real.world.domain.user.entity.User;
 
 @Getter
 @Entity(name = "comments")
@@ -26,13 +25,11 @@ public class Comment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "article_id")
-    private Article article;
+    @Column(name = "article_id")
+    private Long articleId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+    @Column(name = "user_id")
+    private Long userId;
 
     @Column(nullable = false)
     private String body;
@@ -48,9 +45,10 @@ public class Comment {
     protected Comment() {
     }
 
-    public Comment(Article article, User user, String body) {
-        this.article = article;
-        this.user = user;
+    public Comment(Long articleId, Long userId, String body) {
+        this.articleId = articleId;
+        this.userId = userId;
         this.body = body;
     }
+
 }

--- a/src/main/java/real/world/domain/article/entity/Favorite.java
+++ b/src/main/java/real/world/domain/article/entity/Favorite.java
@@ -1,14 +1,12 @@
 package real.world.domain.article.entity;
 
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import java.io.Serializable;
 import lombok.Getter;
-import real.world.domain.user.entity.User;
 
 @Getter
 @Entity(name = "favorites")
@@ -16,32 +14,30 @@ import real.world.domain.user.entity.User;
 public class Favorite {
 
     @Id
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
+    @Column(name = "user_id")
+    private Long userId;
 
     @Id
-    @ManyToOne
-    @JoinColumn(name = "article_id")
-    private Article article;
+    @Column(name = "article_id")
+    private Long articleId;
 
     protected Favorite() {
     }
 
-    public Favorite(User user, Article article) {
-        this.user = user;
-        this.article = article;
+    public Favorite(Long userId, Long articleId) {
+        this.userId = userId;
+        this.articleId = articleId;
     }
 
-    static class FavoriteId implements Serializable {
+    public static class FavoriteId implements Serializable {
 
-        private final Long user;
+        private final Long userId;
 
-        private final Long article;
+        private final Long articleId;
 
-        public FavoriteId(Long user, Long article) {
-            this.user = user;
-            this.article = article;
+        public FavoriteId(Long userId, Long articleId) {
+            this.userId = userId;
+            this.articleId = articleId;
         }
     }
 

--- a/src/main/java/real/world/domain/article/query/ArticleQueryRepository.java
+++ b/src/main/java/real/world/domain/article/query/ArticleQueryRepository.java
@@ -6,4 +6,6 @@ public interface ArticleQueryRepository{
 
     Optional<ArticleView> findById(Long loginId, Long id);
 
+    Optional<ArticleView> findBySlug(Long loginId, String slug);
+
 }

--- a/src/main/java/real/world/domain/article/query/ArticleQueryRepositoryImpl.java
+++ b/src/main/java/real/world/domain/article/query/ArticleQueryRepositoryImpl.java
@@ -3,7 +3,6 @@ package real.world.domain.article.query;
 import static real.world.domain.article.entity.QArticle.article;
 import static real.world.domain.article.entity.QFavorite.favorite;
 
-import com.querydsl.core.types.Predicate;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;

--- a/src/main/java/real/world/domain/article/query/ArticleQueryRepositoryImpl.java
+++ b/src/main/java/real/world/domain/article/query/ArticleQueryRepositoryImpl.java
@@ -3,6 +3,7 @@ package real.world.domain.article.query;
 import static real.world.domain.article.entity.QArticle.article;
 import static real.world.domain.article.entity.QFavorite.favorite;
 
+import com.querydsl.core.types.Predicate;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
@@ -28,6 +29,19 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
                 .from(favorite)
                 .where(favorite.article.id.eq(id))
         )).from(article).where(article.id.eq(id)).fetchOne());
+    }
+
+    @Override
+    public Optional<ArticleView> findBySlug(Long loginId, String slug) {
+        return Optional.ofNullable(factory.select(new QArticleView(
+            article,
+            JPAExpressions.selectFrom(favorite)
+                .where(favorite.user.id.eq(loginId).and(favorite.article.slug.eq(slug)))
+                .exists(),
+            JPAExpressions.select(favorite.count())
+                .from(favorite)
+                .where(favorite.article.slug.eq(slug))
+        )).from(article).where(article.slug.eq(slug)).fetchOne());
     }
 
 }

--- a/src/main/java/real/world/domain/article/query/ArticleQueryRepositoryImpl.java
+++ b/src/main/java/real/world/domain/article/query/ArticleQueryRepositoryImpl.java
@@ -22,25 +22,21 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
         return Optional.ofNullable(factory.select(new QArticleView(
             article,
             JPAExpressions.selectFrom(favorite)
-                .where(favorite.user.id.eq(loginId).and(favorite.article.id.eq(id)))
+                .where(favorite.userId.eq(loginId).and(favorite.articleId.eq(id)))
                 .exists(),
             JPAExpressions.select(favorite.count())
                 .from(favorite)
-                .where(favorite.article.id.eq(id))
+                .where(favorite.articleId.eq(id))
         )).from(article).where(article.id.eq(id)).fetchOne());
     }
 
     @Override
     public Optional<ArticleView> findBySlug(Long loginId, String slug) {
-        return Optional.ofNullable(factory.select(new QArticleView(
-            article,
-            JPAExpressions.selectFrom(favorite)
-                .where(favorite.user.id.eq(loginId).and(favorite.article.slug.eq(slug)))
-                .exists(),
-            JPAExpressions.select(favorite.count())
-                .from(favorite)
-                .where(favorite.article.slug.eq(slug))
-        )).from(article).where(article.slug.eq(slug)).fetchOne());
+        final Long id = factory.select(article.id)
+            .from(article)
+            .where(article.slug.eq(slug))
+            .fetchOne();
+        return findById(loginId, id);
     }
 
 }

--- a/src/main/java/real/world/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/real/world/domain/article/repository/ArticleRepository.java
@@ -10,4 +10,8 @@ public interface ArticleRepository extends Repository<Article, Long> {
 
     Optional<Article> findById(Long id);
 
+    Optional<Article> findBySlug(String slug);
+
+    void delete(Article article);
+
 }

--- a/src/main/java/real/world/domain/article/service/ArticleQueryService.java
+++ b/src/main/java/real/world/domain/article/service/ArticleQueryService.java
@@ -23,4 +23,10 @@ public class ArticleQueryService {
         return ArticleResponse.of(articleView);
     }
 
+    public ArticleResponse getArticle(Long loginId, String slug) {
+        final ArticleView articleView = articleQueryRepository.findBySlug(loginId, slug)
+            .orElseThrow(ArticleNotFoundException::new);
+        return ArticleResponse.of(articleView);
+    }
+
 }

--- a/src/main/java/real/world/domain/article/service/ArticleService.java
+++ b/src/main/java/real/world/domain/article/service/ArticleService.java
@@ -6,10 +6,8 @@ import real.world.domain.article.dto.request.ArticleUpdateRequest;
 import real.world.domain.article.dto.request.UploadRequest;
 import real.world.domain.article.entity.Article;
 import real.world.domain.article.repository.ArticleRepository;
-import real.world.domain.user.entity.User;
 import real.world.domain.user.repository.UserRepository;
 import real.world.error.exception.ArticleNotFoundException;
-import real.world.error.exception.UserIdNotExistException;
 
 @Service
 public class ArticleService {
@@ -29,9 +27,7 @@ public class ArticleService {
 
     @Transactional
     public Long upload(Long loginId, UploadRequest request) {
-        final User user = userRepository.findById(loginId)
-            .orElseThrow(UserIdNotExistException::new);
-        final Article article = requestToEntity(user, request);
+        final Article article = requestToEntity(loginId, request);
         articleRepository.save(article);
         return article.getId();
     }
@@ -53,9 +49,9 @@ public class ArticleService {
         articleRepository.delete(article);
     }
 
-    private Article requestToEntity(User user, UploadRequest request) {
+    private Article requestToEntity(Long loginId, UploadRequest request) {
         return new Article(
-            user,
+            loginId,
             request.getTitle(),
             slugTranslator,
             request.getDescription(),

--- a/src/main/java/real/world/domain/article/service/ArticleService.java
+++ b/src/main/java/real/world/domain/article/service/ArticleService.java
@@ -6,21 +6,16 @@ import real.world.domain.article.dto.request.ArticleUpdateRequest;
 import real.world.domain.article.dto.request.UploadRequest;
 import real.world.domain.article.entity.Article;
 import real.world.domain.article.repository.ArticleRepository;
-import real.world.domain.user.repository.UserRepository;
 import real.world.error.exception.ArticleNotFoundException;
 
 @Service
 public class ArticleService {
 
-    private final UserRepository userRepository;
-
     private final ArticleRepository articleRepository;
 
     private final SlugTranslator slugTranslator;
 
-    public ArticleService(UserRepository userRepository, ArticleRepository articleRepository,
-        SlugTranslator slugTranslator) {
-        this.userRepository = userRepository;
+    public ArticleService(ArticleRepository articleRepository, SlugTranslator slugTranslator) {
         this.articleRepository = articleRepository;
         this.slugTranslator = slugTranslator;
     }
@@ -34,10 +29,10 @@ public class ArticleService {
 
     @Transactional
     public Long update(Long loginId, String slug, ArticleUpdateRequest request) {
-        final Article updateArticle = requestToEntity(request);
+        final Article updateArticle = requestToEntity(loginId, request);
         final Article article = articleRepository.findBySlug(slug)
             .orElseThrow(ArticleNotFoundException::new);
-        article.update(loginId, updateArticle);
+        article.update(updateArticle);
         return article.getId();
     }
 
@@ -60,8 +55,9 @@ public class ArticleService {
         );
     }
 
-    private Article requestToEntity(ArticleUpdateRequest request) {
+    private Article requestToEntity(Long loginId, ArticleUpdateRequest request) {
         return new Article(
+            loginId,
             request.getTitle(),
             slugTranslator,
             request.getDescription(),

--- a/src/main/java/real/world/domain/article/service/ArticleService.java
+++ b/src/main/java/real/world/domain/article/service/ArticleService.java
@@ -32,6 +32,7 @@ public class ArticleService {
         final Article updateArticle = requestToEntity(loginId, request);
         final Article article = articleRepository.findBySlug(slug)
             .orElseThrow(ArticleNotFoundException::new);
+        article.verifyUserId(loginId);
         article.update(updateArticle);
         return article.getId();
     }

--- a/src/main/java/real/world/domain/article/service/SlugUUIDTranslator.java
+++ b/src/main/java/real/world/domain/article/service/SlugUUIDTranslator.java
@@ -8,8 +8,7 @@ public class SlugUUIDTranslator implements SlugTranslator {
 
     public String translate(String title) {
         final String suffix = UUID.randomUUID().toString().substring(0, 6);
-        final String prefix = title.toLowerCase().replaceAll("\\s+", "-");
-        return prefix + "-" + suffix;
+        return title.toLowerCase().replaceAll("\\s+", "-") + "-" + suffix;
     }
 
 }

--- a/src/main/java/real/world/domain/article/service/SlugUUIDTranslator.java
+++ b/src/main/java/real/world/domain/article/service/SlugUUIDTranslator.java
@@ -7,8 +7,9 @@ import org.springframework.stereotype.Component;
 public class SlugUUIDTranslator implements SlugTranslator {
 
     public String translate(String title) {
-        final String suffix =  UUID.randomUUID().toString().substring(0, 6);
-        return title.toLowerCase().replace("\\s+", "-") + "-" + suffix;
+        final String suffix = UUID.randomUUID().toString().substring(0, 6);
+        final String prefix = title.toLowerCase().replaceAll("\\s+", "-");
+        return prefix + "-" + suffix;
     }
 
 }

--- a/src/main/java/real/world/domain/follow/entity/Follow.java
+++ b/src/main/java/real/world/domain/follow/entity/Follow.java
@@ -32,15 +32,10 @@ public class Follow {
         this.follower = follower;
     }
 
-    static class FollowId implements Serializable {
+    static public class FollowId implements Serializable {
+        Long user;
+        Long follower;
 
-        private final Long user;
-        private final Long follower;
-
-        public FollowId(Long user, Long follower) {
-            this.user = user;
-            this.follower = follower;
-        }
     }
 
 }

--- a/src/main/java/real/world/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/real/world/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,16 @@
+package real.world.domain.follow.repository;
+
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
+import real.world.domain.follow.entity.Follow;
+import real.world.domain.follow.entity.Follow.FollowId;
+
+public interface FollowRepository extends Repository<Follow, FollowId> {
+
+    Follow save(Follow follow);
+
+    boolean existsByUserIdAndFollowerId(Long userId, Long followerId);
+
+    void delete(Follow follow);
+
+}

--- a/src/main/java/real/world/domain/follow/service/FollowService.java
+++ b/src/main/java/real/world/domain/follow/service/FollowService.java
@@ -1,0 +1,59 @@
+package real.world.domain.follow.service;
+
+import org.springframework.stereotype.Service;
+import real.world.domain.follow.entity.Follow;
+import real.world.domain.follow.repository.FollowRepository;
+import real.world.domain.profile.dto.response.ProfileResponse;
+import real.world.domain.user.entity.User;
+import real.world.domain.user.repository.UserRepository;
+import real.world.error.exception.AlreadyFollowingException;
+import real.world.error.exception.FollowNotExistException;
+import real.world.error.exception.RecursiveFollowException;
+import real.world.error.exception.UserIdNotExistException;
+import real.world.error.exception.UsernameNotExistException;
+
+@Service
+public class FollowService {
+
+    private final UserRepository userRepository;
+
+    private final FollowRepository followRepository;
+
+    public FollowService(UserRepository userRepository, FollowRepository followRepository) {
+        this.userRepository = userRepository;
+        this.followRepository = followRepository;
+    }
+
+    public ProfileResponse follow(Long loginId, String username) {
+        final User user = userRepository.findByUsername(username)
+            .orElseThrow(UsernameNotExistException::new);
+        final User loginUser = userRepository.findById(loginId)
+            .orElseThrow(UserIdNotExistException::new);
+
+        if(user.getId().equals(loginId)) { throw new RecursiveFollowException(); }
+        if(followRepository.existsByUserIdAndFollowerId(user.getId(), loginId)) {
+            throw new AlreadyFollowingException();
+        }
+
+        final Follow follow = new Follow(user, loginUser);
+        followRepository.save(follow);
+        return ProfileResponse.of(user, true);
+    }
+
+    public ProfileResponse unfollow(Long loginId, String username) {
+        final User user = userRepository.findByUsername(username)
+            .orElseThrow(UsernameNotExistException::new);
+        final User loginUser = userRepository.findById(loginId)
+            .orElseThrow(UserIdNotExistException::new);
+
+        if(user.getId().equals(loginId)) { throw new RecursiveFollowException(); }
+        if(!followRepository.existsByUserIdAndFollowerId(user.getId(), loginId)) {
+            throw new FollowNotExistException();
+        }
+
+        final Follow follow = new Follow(user, loginUser);
+        followRepository.delete(follow);
+        return ProfileResponse.of(user, false);
+    }
+
+}

--- a/src/main/java/real/world/domain/profile/controller/ProfileController.java
+++ b/src/main/java/real/world/domain/profile/controller/ProfileController.java
@@ -1,0 +1,47 @@
+package real.world.domain.profile.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import real.world.domain.auth.annotation.Auth;
+import real.world.domain.follow.service.FollowService;
+import real.world.domain.profile.dto.response.ProfileResponse;
+import real.world.domain.profile.service.ProfileQueryService;
+
+@RestController
+public class ProfileController {
+
+    private final FollowService followService;
+
+    private final ProfileQueryService profileQueryService;
+
+    public ProfileController(FollowService followService, ProfileQueryService profileQueryService) {
+        this.followService = followService;
+        this.profileQueryService = profileQueryService;
+    }
+
+    @GetMapping("/profiles/{username}")
+    public ResponseEntity<ProfileResponse> getProfile(@Auth Long loginId, @PathVariable("username") String username) {
+        final ProfileResponse response = profileQueryService.getProfile(loginId, username);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @PostMapping("/profiles/{username}/follow")
+    public ResponseEntity<ProfileResponse> follow(@Auth Long loginId, @PathVariable("username") String username) {
+        final ProfileResponse response = followService.follow(loginId, username);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @PostMapping("/profiles/{username}/unfollow")
+    public ResponseEntity<ProfileResponse> unfollow(@Auth Long loginId, @PathVariable("username") String username) {
+        final ProfileResponse response = followService.unfollow(loginId, username);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/real/world/domain/profile/dto/response/ProfileResponse.java
+++ b/src/main/java/real/world/domain/profile/dto/response/ProfileResponse.java
@@ -1,0 +1,42 @@
+package real.world.domain.profile.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import real.world.domain.user.dto.ProfileDto;
+import real.world.domain.user.entity.User;
+
+@Getter
+@JsonRootName(value = "profile")
+@NoArgsConstructor
+public class ProfileResponse {
+
+    private String username;
+
+    private String bio;
+
+    private String image;
+
+    private boolean following;
+
+    private ProfileResponse(String username, String bio, String image, boolean following) {
+        this.username = username;
+        this.bio = bio;
+        this.image = image;
+        this.following = following;
+    }
+
+    public static ProfileResponse of(User user, boolean following) {
+        return new ProfileResponse(user.getUsername(), user.getBio(), user.getImageUrl(), following);
+    }
+
+    public static ProfileResponse of(ProfileDto profile) {
+        return new ProfileResponse(
+            profile.getUsername(),
+            profile.getBio(),
+            profile.getImage(),
+            profile.isFollowing()
+        );
+    }
+
+}

--- a/src/main/java/real/world/domain/profile/repository/ProfileQueryRepository.java
+++ b/src/main/java/real/world/domain/profile/repository/ProfileQueryRepository.java
@@ -1,0 +1,10 @@
+package real.world.domain.profile.repository;
+
+import java.util.Optional;
+import real.world.domain.user.dto.ProfileDto;
+
+public interface ProfileQueryRepository {
+
+    Optional<ProfileDto> findByLoginIdAndUsername(Long loginId, String username);
+
+}

--- a/src/main/java/real/world/domain/profile/repository/ProfileQueryRepositoryImpl.java
+++ b/src/main/java/real/world/domain/profile/repository/ProfileQueryRepositoryImpl.java
@@ -1,0 +1,38 @@
+package real.world.domain.profile.repository;
+
+import static real.world.domain.follow.entity.QFollow.follow;
+import static real.world.domain.user.entity.QUser.user;
+
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+import real.world.domain.user.dto.ProfileDto;
+import real.world.domain.user.dto.QProfileDto;
+
+@Repository
+public class ProfileQueryRepositoryImpl implements ProfileQueryRepository {
+
+    public final JPAQueryFactory factory;
+
+    public ProfileQueryRepositoryImpl(JPAQueryFactory factory) {
+        this.factory = factory;
+    }
+
+    @Override
+    public Optional<ProfileDto> findByLoginIdAndUsername(Long loginId, String username) {
+        return Optional.ofNullable(
+            factory
+                .select(
+                    new QProfileDto(
+                        user,
+                        JPAExpressions.
+                            selectFrom(follow)
+                            .where(follow.follower.id.eq(loginId).and(follow.user.username.eq(username)))
+                            .exists()))
+                .from(user).
+                where(user.username.eq(username)).
+                fetchOne());
+    }
+
+}

--- a/src/main/java/real/world/domain/profile/service/ProfileQueryService.java
+++ b/src/main/java/real/world/domain/profile/service/ProfileQueryService.java
@@ -1,0 +1,24 @@
+package real.world.domain.profile.service;
+
+import org.springframework.stereotype.Service;
+import real.world.domain.profile.dto.response.ProfileResponse;
+import real.world.domain.profile.repository.ProfileQueryRepository;
+import real.world.domain.user.dto.ProfileDto;
+import real.world.error.exception.UsernameNotExistException;
+
+@Service
+public class ProfileQueryService {
+
+    private final ProfileQueryRepository profileQueryRepository;
+
+    public ProfileQueryService(ProfileQueryRepository profileQueryRepository) {
+        this.profileQueryRepository = profileQueryRepository;
+    }
+
+    public ProfileResponse getProfile(Long loginId, String username) {
+        final ProfileDto profile = profileQueryRepository.findByLoginIdAndUsername(loginId, username)
+            .orElseThrow(UsernameNotExistException::new);
+        return ProfileResponse.of(profile);
+    }
+
+}

--- a/src/main/java/real/world/domain/user/controller/UserController.java
+++ b/src/main/java/real/world/domain/user/controller/UserController.java
@@ -54,25 +54,20 @@ public class UserController {
         final String token = jwtUtil.generateJwtToken(id, authoritiesString);
 
         httpServletResponse.addHeader(AUTH_HEADER, AUTH_TYPE + " " + token);
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     @GetMapping("/user")
     public ResponseEntity<UserResponse> currentUser(@Auth Long loginId) {
         final UserResponse response = userService.getUser(loginId);
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     @PutMapping("/user")
     public ResponseEntity<UserResponse> update(@Auth Long loginId,
         @RequestBody UpdateRequest updateRequest) {
         final UserResponse response = userService.update(loginId, updateRequest);
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
-    }
-
-    @GetMapping("/profiles")
-    public ResponseEntity<String> checkAuth(@Auth Long loginId) {
-        return new ResponseEntity<>("ok", HttpStatus.CREATED);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/real/world/domain/user/dto/ProfileDto.java
+++ b/src/main/java/real/world/domain/user/dto/ProfileDto.java
@@ -1,5 +1,6 @@
 package real.world.domain.user.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import real.world.domain.user.entity.User;
@@ -20,6 +21,14 @@ public class ProfileDto {
         this.username = username;
         this.bio = bio;
         this.image = image;
+        this.following = following;
+    }
+
+    @QueryProjection
+    public ProfileDto(User user, boolean following) {
+        this.username = user.getUsername();
+        this.bio = user.getBio();
+        this.image = user.getImageUrl();
         this.following = following;
     }
 

--- a/src/main/java/real/world/domain/user/entity/UserRole.java
+++ b/src/main/java/real/world/domain/user/entity/UserRole.java
@@ -2,9 +2,10 @@ package real.world.domain.user.entity;
 
 public enum UserRole {
     ROLE_USER,
-    ROLE_ADMIN;
+    ROLE_ANONYMOUS;
 
     public String getValue() {
         return this.toString();
     }
+
 }

--- a/src/main/java/real/world/domain/user/repository/UserRepository.java
+++ b/src/main/java/real/world/domain/user/repository/UserRepository.java
@@ -10,6 +10,8 @@ public interface UserRepository extends Repository<User, Long> {
 
     Optional<User> findById(Long id);
 
+    Optional<User> findByUsername(String username);
+
     Optional<User> findByEmail(String email);
 
     boolean existsByUsername(String username);

--- a/src/main/java/real/world/error/ErrorCode.java
+++ b/src/main/java/real/world/error/ErrorCode.java
@@ -16,6 +16,12 @@ public enum ErrorCode {
     EMAIL_INVALID(HttpStatus.UNPROCESSABLE_ENTITY, "email", "invalid."),
     USERNAME_ALREADY_EXIST(HttpStatus.UNPROCESSABLE_ENTITY, "username", "already exists."),
     USERID_NOT_EXIST(HttpStatus.UNPROCESSABLE_ENTITY, "userId", "not exists."),
+    USERNAME_NOT_EXIST(HttpStatus.UNPROCESSABLE_ENTITY, "userId", "not exists."),
+
+    // Follow
+    RECURSIVE_FOLLOW(HttpStatus.UNPROCESSABLE_ENTITY, "recursive follow", "cannot follow self"),
+    ALREADY_FOLLOWING(HttpStatus.UNPROCESSABLE_ENTITY, "follow", "already follow."),
+    FOLLOW_NOT_EXIST(HttpStatus.UNPROCESSABLE_ENTITY, "follow", "not exists."),
 
     // Article
     ARTICLE_NOT_FOUND(HttpStatus.UNPROCESSABLE_ENTITY, "article", "not found."),
@@ -23,7 +29,7 @@ public enum ErrorCode {
 
     // Authentication
     AUTH_FORMAT_INVALID(HttpStatus.UNPROCESSABLE_ENTITY, "authentication", "format invalid."),
-    USERNAME_NOT_EXIST(HttpStatus.UNPROCESSABLE_ENTITY, "authentication", "user is not exist."),
+    AUTH_USERNAME_NOT_EXIST(HttpStatus.UNPROCESSABLE_ENTITY, "authentication", "user is not exist."),
     WRONG_PASSWORD(HttpStatus.UNPROCESSABLE_ENTITY, "authentication", "wrong password."),
 
     // JWT

--- a/src/main/java/real/world/error/ErrorCode.java
+++ b/src/main/java/real/world/error/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
 
     // Article
     ARTICLE_NOT_FOUND(HttpStatus.UNPROCESSABLE_ENTITY, "article", "not found."),
+    ARTICLE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "article", "you have no authority"),
 
     // Authentication
     AUTH_FORMAT_INVALID(HttpStatus.UNPROCESSABLE_ENTITY, "authentication", "format invalid."),

--- a/src/main/java/real/world/error/exception/AlreadyFollowingException.java
+++ b/src/main/java/real/world/error/exception/AlreadyFollowingException.java
@@ -1,0 +1,11 @@
+package real.world.error.exception;
+
+import real.world.error.ErrorCode;
+
+public class AlreadyFollowingException extends BusinessException{
+
+    public AlreadyFollowingException() {
+        super(ErrorCode.ALREADY_FOLLOWING);
+    }
+
+}

--- a/src/main/java/real/world/error/exception/ArticleUnauthorizedException.java
+++ b/src/main/java/real/world/error/exception/ArticleUnauthorizedException.java
@@ -1,0 +1,11 @@
+package real.world.error.exception;
+
+import real.world.error.ErrorCode;
+
+public class ArticleUnauthorizedException extends BusinessException {
+
+    public ArticleUnauthorizedException() {
+        super(ErrorCode.ARTICLE_UNAUTHORIZED);
+    }
+
+}

--- a/src/main/java/real/world/error/exception/FollowNotExistException.java
+++ b/src/main/java/real/world/error/exception/FollowNotExistException.java
@@ -1,0 +1,11 @@
+package real.world.error.exception;
+
+import real.world.error.ErrorCode;
+
+public class FollowNotExistException extends BusinessException{
+
+    public FollowNotExistException() {
+        super(ErrorCode.FOLLOW_NOT_EXIST);
+    }
+
+}

--- a/src/main/java/real/world/error/exception/RecursiveFollowException.java
+++ b/src/main/java/real/world/error/exception/RecursiveFollowException.java
@@ -1,0 +1,11 @@
+package real.world.error.exception;
+
+import real.world.error.ErrorCode;
+
+public class RecursiveFollowException extends BusinessException{
+
+    public RecursiveFollowException() {
+        super(ErrorCode.RECURSIVE_FOLLOW);
+    }
+
+}

--- a/src/main/java/real/world/error/exception/UsernameNotExistException.java
+++ b/src/main/java/real/world/error/exception/UsernameNotExistException.java
@@ -1,0 +1,11 @@
+package real.world.error.exception;
+
+import real.world.error.ErrorCode;
+
+public class UsernameNotExistException extends BusinessException{
+
+    public UsernameNotExistException() {
+        super(ErrorCode.USERNAME_NOT_EXIST);
+    }
+
+}

--- a/src/main/java/real/world/security/service/UserDetailsByEmailService.java
+++ b/src/main/java/real/world/security/service/UserDetailsByEmailService.java
@@ -22,7 +22,7 @@ public class UserDetailsByEmailService implements CustomUserDetailsService {
     public UserDetails loadUserByPrincipal(String email) throws AuthenticationException {
         final User user = userRepository.findByEmail(email)
             .orElseThrow(
-                () -> new AuthenticationErrorCodeException(ErrorCode.USERNAME_NOT_EXIST));
+                () -> new AuthenticationErrorCodeException(ErrorCode.AUTH_USERNAME_NOT_EXIST));
         final Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority(user.getRole().getValue()));
         return new CustomUserDetails(user, authorities);
     }

--- a/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
+++ b/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
@@ -27,7 +27,6 @@ import real.world.domain.article.dto.response.ArticleResponse;
 import real.world.domain.article.query.ArticleView;
 import real.world.domain.article.service.ArticleQueryService;
 import real.world.domain.article.service.ArticleService;
-import real.world.domain.user.entity.User;
 import real.world.support.TestSecurityConfig;
 import real.world.support.WithMockUserId;
 import real.world.support.WithMockUserIdFactory;
@@ -60,8 +59,7 @@ public class ArticleControllerTest {
         @WithMockUserId(user = JOHN)
         void 상태코드200_으로_성공() throws Exception {
             // given
-            final User user = JOHN.생성();
-            final ArticleView article = 게시물.뷰_생성(user);
+            final ArticleView article = 게시물.뷰_생성(JOHN.getId());
             final UploadRequest request = 게시물.업로드를_한다();
             final long 게시물_ID = 1L;
 

--- a/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
+++ b/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
@@ -1,19 +1,26 @@
 package real.world.domain.article.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static real.world.fixture.ArticleFixtures.게시물;
 import static real.world.fixture.UserFixtures.JOHN;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import jakarta.annotation.PostConstruct;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -22,11 +29,13 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import real.world.config.WebMvcConfig;
+import real.world.domain.article.dto.request.ArticleUpdateRequest;
 import real.world.domain.article.dto.request.UploadRequest;
 import real.world.domain.article.dto.response.ArticleResponse;
 import real.world.domain.article.query.ArticleView;
 import real.world.domain.article.service.ArticleQueryService;
 import real.world.domain.article.service.ArticleService;
+import real.world.error.exception.ArticleNotFoundException;
 import real.world.support.TestSecurityConfig;
 import real.world.support.WithMockUserId;
 import real.world.support.WithMockUserIdFactory;
@@ -50,10 +59,11 @@ public class ArticleControllerTest {
     void setUp() {
         objectMapper = new ObjectMapper();
         objectMapper.enable(SerializationFeature.WRAP_ROOT_VALUE);
+        objectMapper.enable(DeserializationFeature.UNWRAP_ROOT_VALUE);
     }
 
     @Nested
-    class 게시물업로드 {
+    class 게시물_업로드 {
 
         @Test
         @WithMockUserId(user = JOHN)
@@ -63,7 +73,7 @@ public class ArticleControllerTest {
             final UploadRequest request = 게시물.업로드를_한다();
             final long 게시물_ID = 1L;
 
-            given(articleService.upload(any(), any())).willReturn(게시물_ID);
+            given(articleService.upload(eq(JOHN.getId()), any())).willReturn(게시물_ID);
             given(articleQueryService.getArticle(JOHN.getId(), 게시물_ID))
                 .willReturn(ArticleResponse.of(article));
 
@@ -75,7 +85,143 @@ public class ArticleControllerTest {
             // then
             resultActions.andExpect(status().isCreated())
                 .andDo(print());
-            verify(articleService).upload(any(), any());
+            verify(articleService).upload(eq(JOHN.getId()), any());
+        }
+
+    }
+
+    @Nested
+    class 게시물_조회 {
+
+        @Test
+        @WithMockUserId(user = JOHN)
+        void 상태코드200_으로_성공() throws Exception {
+            // given
+            final ArticleView article = 게시물.뷰_생성(JOHN.getId());
+            final String slug = article.getSlug();
+            final long 게시물_ID = 1L;
+
+            given(articleQueryService.getArticle(JOHN.getId(), 게시물_ID))
+                .willReturn(ArticleResponse.of(article));
+
+            // when
+            final ResultActions resultActions = mockmvc.perform(
+                get("/articles/{slug}", slug).contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            resultActions.andExpect(status().isOk())
+                .andDo(print());
+            verify(articleQueryService).getArticle(eq(JOHN.getId()), eq(slug));
+        }
+
+        @Test
+        @WithMockUserId(user = JOHN)
+        void 슬럭에_해당하는_아티클이_없다면_상태코드422로_실패() throws Exception {
+            // given
+            final String slug = 게시물.getSlug();
+            given(articleQueryService.getArticle(eq(JOHN.getId()), eq(slug))).willThrow(
+                new ArticleNotFoundException()
+            );
+
+            // when
+            final ResultActions resultActions = mockmvc.perform(
+                get("/articles/{slug}", slug).contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            resultActions.andExpect(status().isUnprocessableEntity())
+                .andDo(print());
+        }
+
+    }
+
+    @Nested
+    class 게시물_수정 {
+
+        @Test
+        @WithMockUserId(user = JOHN)
+        void 상태코드200_으로_성공() throws Exception {
+            // given
+            final ArticleView article = 게시물.뷰_생성(JOHN.getId());
+            final ArticleUpdateRequest request = 게시물.수정을_한다();
+            final String slug = article.getSlug();
+            final long 게시물_ID = 1L;
+
+            given(articleService.update(eq(JOHN.getId()), eq(slug), any())).willReturn(게시물_ID);
+            given(articleQueryService.getArticle(JOHN.getId(), 게시물_ID))
+                .willReturn(ArticleResponse.of(article));
+
+            // when
+            final ResultActions resultActions = mockmvc.perform(
+                put("/articles/{slug}", slug).contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // then
+            resultActions.andExpect(status().isOk())
+                .andDo(print());
+            verify(articleService).update(eq(JOHN.getId()), eq(slug), any());
+        }
+
+        @Test
+        @WithMockUserId(user = JOHN)
+        void 슬럭에_해당하는_아티클이_없다면_상태코드422로_실패() throws Exception {
+            // given
+            final ArticleView article = 게시물.뷰_생성(JOHN.getId());
+            final ArticleUpdateRequest request = 게시물.수정을_한다();
+            final String slug = article.getSlug();
+
+            given(articleService.update(eq(JOHN.getId()), eq(slug), any())).willThrow(
+                new ArticleNotFoundException()
+            );
+
+            // when
+            final ResultActions resultActions = mockmvc.perform(
+                put("/articles/{slug}", slug).contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // then
+            resultActions.andExpect(status().isUnprocessableEntity())
+                .andDo(print());
+        }
+
+    }
+
+    @Nested
+    class 게시물_삭제 {
+
+        @Test
+        @WithMockUserId(user = JOHN)
+        void 상태코드200_으로_성공() throws Exception {
+            // given
+            final ArticleView article = 게시물.뷰_생성(JOHN.getId());
+            final String slug = article.getSlug();
+
+            // when
+            final ResultActions resultActions = mockmvc.perform(
+                delete("/articles/{slug}", slug).contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            resultActions.andExpect(status().isOk())
+                .andDo(print());
+            verify(articleService).delete(eq(JOHN.getId()), eq(slug));
+        }
+
+        @Test
+        @WithMockUserId(user = JOHN)
+        void 슬럭에_해당하는_아티클이_없다면_상태코드422로_실패() throws Exception {
+            // given
+            final ArticleView article = 게시물.뷰_생성(JOHN.getId());
+            final String slug = article.getSlug();
+
+            willThrow(new ArticleNotFoundException()).given(articleService)
+                .delete(eq(JOHN.getId()), eq(slug));
+
+            // when
+            final ResultActions resultActions = mockmvc.perform(
+                delete("/articles/{slug}", slug).contentType(MediaType.APPLICATION_JSON));
+
+            // then
+            resultActions.andExpect(status().isUnprocessableEntity())
+                .andDo(print());
         }
 
     }

--- a/src/test/java/real/world/domain/article/entity/ArticleTest.java
+++ b/src/test/java/real/world/domain/article/entity/ArticleTest.java
@@ -1,0 +1,64 @@
+package real.world.domain.article.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static real.world.fixture.ArticleFixtures.게시물;
+import static real.world.fixture.ArticleFixtures.게시물_2;
+import static real.world.fixture.UserFixtures.ALICE;
+import static real.world.fixture.UserFixtures.JOHN;
+
+import org.junit.jupiter.api.Test;
+import real.world.domain.article.service.SlugTranslator;
+import real.world.error.exception.ArticleUnauthorizedException;
+import real.world.support.StubSlugTranslator;
+
+public class ArticleTest {
+
+    private final SlugTranslator slugTranslator = new StubSlugTranslator();
+
+    @Test
+    void 생성_시_SlugTranslator를_통해_슬럭을_생성한다() {
+        // given
+        final Article article = new Article(JOHN.getId(), 게시물.getTitle(), slugTranslator,
+            게시물.getDescription(), 게시물.getBody(), 게시물.getTags());
+
+        // when & then
+        assertThatThrownBy(() -> article.verifyUserId(ALICE.getId())).isInstanceOf(
+            ArticleUnauthorizedException.class);
+    }
+
+    @Test
+    void verifyUserId는_인자와_아티클의_userId가_다르면_예외를_던진다() {
+        // given & when
+        final Article article = new Article(JOHN.getId(), 게시물.getTitle(), slugTranslator,
+            게시물.getDescription(), 게시물.getBody(), 게시물.getTags());
+
+        // then
+        assertThat(article.getSlug()).isEqualTo(slugTranslator.translate(게시물.getTitle()));
+    }
+
+    @Test
+    void 수정_시_SlugTranslator를_통해_슬럭을_생성한다() {
+        // given & when
+        final Article article = new Article(JOHN.getId(), 게시물.getTitle(), slugTranslator,
+            게시물.getDescription(), 게시물.getBody(), 게시물.getTags());
+        final Article updateArticle = 게시물_2.생성(JOHN.getId());
+        article.update(updateArticle);
+
+        // then
+        assertThat(article.getSlug()).isEqualTo(slugTranslator.translate(게시물_2.getTitle()));
+    }
+
+    @Test
+    void 수정_시_유저ID가_일치하지_않는다면_예외를_던진다() {
+        // given & when
+        final Article article = new Article(JOHN.getId(), 게시물.getTitle(), slugTranslator,
+            게시물.getDescription(), 게시물.getBody(), 게시물.getTags());
+        final Article updateArticle = 게시물_2.생성(ALICE.getId());
+
+        // then
+        assertThatThrownBy(() -> article.update(updateArticle)).isInstanceOf(
+            ArticleUnauthorizedException.class);
+    }
+
+}

--- a/src/test/java/real/world/domain/article/entity/ArticleTest.java
+++ b/src/test/java/real/world/domain/article/entity/ArticleTest.java
@@ -49,16 +49,4 @@ public class ArticleTest {
         assertThat(article.getSlug()).isEqualTo(slugTranslator.translate(게시물_2.getTitle()));
     }
 
-    @Test
-    void 수정_시_유저ID가_일치하지_않는다면_예외를_던진다() {
-        // given & when
-        final Article article = new Article(JOHN.getId(), 게시물.getTitle(), slugTranslator,
-            게시물.getDescription(), 게시물.getBody(), 게시물.getTags());
-        final Article updateArticle = 게시물_2.생성(ALICE.getId());
-
-        // then
-        assertThatThrownBy(() -> article.update(updateArticle)).isInstanceOf(
-            ArticleUnauthorizedException.class);
-    }
-
 }

--- a/src/test/java/real/world/domain/article/query/ArticleQueryRepositoryTest.java
+++ b/src/test/java/real/world/domain/article/query/ArticleQueryRepositoryTest.java
@@ -33,7 +33,7 @@ public class ArticleQueryRepositoryTest {
     private ArticleQueryRepository articleQueryRepository;
 
     @Test
-    void 아티클뷰를_단건_조회한다() {
+    void 아티클뷰를_ID로_단건_조회한다() {
         // given
         final User user = UserFixtures.JOHN.생성();
         userRepository.save(user);
@@ -44,6 +44,31 @@ public class ArticleQueryRepositoryTest {
         // when
         final Optional<ArticleView> articleView = articleQueryRepository.findById(user.getId(),
             article.getId());
+
+        // then
+        assertAll(() -> {
+            assertThat(articleView.isPresent()).isTrue();
+            final ArticleView result = articleView.get();
+            assertThat(result.getTitle()).isEqualTo(article.getTitle());
+            assertThat(result.getDescription()).isEqualTo(article.getDescription());
+            assertThat(result.getSlug()).isEqualTo(article.getSlug());
+            assertThat(result.getBody()).isEqualTo(article.getBody());
+            assertThat(result.getTagList()).containsExactlyInAnyOrderElementsOf(tags);
+        });
+    }
+    
+    @Test
+    void 아티클뷰를_슬럭으로_단건_조회한다() {
+        // given
+        final User user = UserFixtures.JOHN.생성();
+        userRepository.save(user);
+        final Set<String> tags = Set.of("tag1", "tag2");
+        final Article article = ArticleFixtures.게시물.태그와_함께_생성(user.getId(), tags);
+        articleRepository.save(article);
+
+        // when
+        final Optional<ArticleView> articleView = articleQueryRepository.findBySlug(user.getId(),
+            article.getSlug());
 
         // then
         assertAll(() -> {

--- a/src/test/java/real/world/domain/article/query/ArticleQueryRepositoryTest.java
+++ b/src/test/java/real/world/domain/article/query/ArticleQueryRepositoryTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.Optional;
 import java.util.Set;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -39,7 +38,7 @@ public class ArticleQueryRepositoryTest {
         final User user = UserFixtures.JOHN.생성();
         userRepository.save(user);
         final Set<String> tags = Set.of("tag1", "tag2");
-        final Article article = ArticleFixtures.게시물.태그와_함께_생성(user, tags);
+        final Article article = ArticleFixtures.게시물.태그와_함께_생성(user.getId(), tags);
         articleRepository.save(article);
 
         // when

--- a/src/test/java/real/world/domain/article/service/ArticleServiceTest.java
+++ b/src/test/java/real/world/domain/article/service/ArticleServiceTest.java
@@ -1,33 +1,36 @@
 package real.world.domain.article.service;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static real.world.fixture.ArticleFixtures.게시물;
+import static real.world.fixture.ArticleFixtures.게시물_2;
 import static real.world.fixture.UserFixtures.JOHN;
 
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.BDDMockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import real.world.domain.article.dto.request.ArticleUpdateRequest;
 import real.world.domain.article.dto.request.UploadRequest;
 import real.world.domain.article.entity.Article;
 import real.world.domain.article.repository.ArticleRepository;
-import real.world.domain.user.repository.UserRepository;
+import real.world.error.exception.ArticleNotFoundException;
+import real.world.support.StubSlugTranslator;
 
 @ExtendWith(MockitoExtension.class)
 public class ArticleServiceTest {
 
-    private final UserRepository userRepository = BDDMockito.mock(UserRepository.class);
-
     private final ArticleRepository articleRepository = BDDMockito.mock(ArticleRepository.class);
 
-    private final SlugTranslator slugTranslator = BDDMockito.mock(SlugTranslator.class);
+    private final SlugTranslator slugTranslator = new StubSlugTranslator();
 
-    private final ArticleService articleService = new ArticleService(userRepository,
-        articleRepository, slugTranslator);
+    private final ArticleService articleService = new ArticleService(articleRepository,
+        slugTranslator);
 
     @Nested
     class 업로드는 {
@@ -36,7 +39,6 @@ public class ArticleServiceTest {
         void 정상_호출시_포스트를_저장한다() {
             // given
             final UploadRequest request = 게시물.업로드를_한다();
-            given(userRepository.findById(JOHN.getId())).willReturn(Optional.of(JOHN.생성()));
 
             // when
             articleService.upload(JOHN.getId(), request);
@@ -45,17 +47,69 @@ public class ArticleServiceTest {
             verify(articleRepository).save(any(Article.class));
         }
 
+    }
+
+    @Nested
+    class 게시물_수정은 {
+
         @Test
-        void 정상_호출시_번역기를_통해_슬럭을_생성한다() {
+        void 정상_호출시_포스트를_수정한다() {
             // given
-            final UploadRequest request = 게시물.업로드를_한다();
-            given(userRepository.findById(JOHN.getId())).willReturn(Optional.of(JOHN.생성()));
+            final Long userId = JOHN.getId();
+            final String slug = 게시물.getSlug();
+            final ArticleUpdateRequest request = 게시물_2.수정을_한다();
+            final Article article = BDDMockito.mock(Article.class);
+            given(articleRepository.findBySlug(slug)).willReturn(Optional.of(article));
 
             // when
-            articleService.upload(JOHN.getId(), request);
+            articleService.update(userId, slug, request);
 
             // then
-            verify(slugTranslator).translate(request.getTitle());
+            verify(article).update(any());
+        }
+
+        @Test
+        void 슬럭에_해당하는_아티클이_없다면_예외를_던진다() {
+            // given
+            final Long userId = JOHN.getId();
+            final String slug = 게시물.getSlug();
+            final ArticleUpdateRequest request = 게시물_2.수정을_한다();
+
+            // when & then
+            Assertions.assertThatThrownBy(() -> articleService.update(userId, slug, request))
+                .isInstanceOf(ArticleNotFoundException.class);
+        }
+
+    }
+
+    @Nested
+    class 게시물_삭제는 {
+
+        @Test
+        void 정상_호출시_userId를_검증하고_포스트를_삭제한다() {
+            // given
+            final Long userId = JOHN.getId();
+            final String slug = 게시물.getSlug();
+            final Article article = BDDMockito.mock(Article.class);
+            given(articleRepository.findBySlug(slug)).willReturn(Optional.of(article));
+
+            // when
+            articleService.delete(userId, slug);
+
+            // then
+            verify(article).verifyUserId(anyLong());
+            verify(articleRepository).delete(any());
+        }
+
+        @Test
+        void 슬럭에_해당하는_아티클이_없다면_예외를_던진다() {
+            // given
+            final Long userId = JOHN.getId();
+            final String slug = 게시물.getSlug();
+
+            // when & then
+            Assertions.assertThatThrownBy(() -> articleService.delete(userId, slug))
+                .isInstanceOf(ArticleNotFoundException.class);
         }
 
     }

--- a/src/test/java/real/world/domain/article/service/ArticleServiceTest.java
+++ b/src/test/java/real/world/domain/article/service/ArticleServiceTest.java
@@ -1,5 +1,7 @@
 package real.world.domain.article.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -9,7 +11,6 @@ import static real.world.fixture.ArticleFixtures.게시물_2;
 import static real.world.fixture.UserFixtures.JOHN;
 
 import java.util.Optional;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,7 +54,7 @@ public class ArticleServiceTest {
     class 게시물_수정은 {
 
         @Test
-        void 정상_호출시_포스트를_수정한다() {
+        void 정상_호출시_userId를_검증하고_포스트를_수정한다() {
             // given
             final Long userId = JOHN.getId();
             final String slug = 게시물.getSlug();
@@ -65,7 +66,10 @@ public class ArticleServiceTest {
             articleService.update(userId, slug, request);
 
             // then
-            verify(article).update(any());
+            assertAll(() -> {
+                verify(article).verifyUserId(anyLong());
+                verify(article).update(any());
+            });
         }
 
         @Test
@@ -76,7 +80,7 @@ public class ArticleServiceTest {
             final ArticleUpdateRequest request = 게시물_2.수정을_한다();
 
             // when & then
-            Assertions.assertThatThrownBy(() -> articleService.update(userId, slug, request))
+            assertThatThrownBy(() -> articleService.update(userId, slug, request))
                 .isInstanceOf(ArticleNotFoundException.class);
         }
 
@@ -97,8 +101,10 @@ public class ArticleServiceTest {
             articleService.delete(userId, slug);
 
             // then
-            verify(article).verifyUserId(anyLong());
-            verify(articleRepository).delete(any());
+            assertAll(() -> {
+                verify(article).verifyUserId(anyLong());
+                verify(articleRepository).delete(any());
+            });
         }
 
         @Test
@@ -108,7 +114,7 @@ public class ArticleServiceTest {
             final String slug = 게시물.getSlug();
 
             // when & then
-            Assertions.assertThatThrownBy(() -> articleService.delete(userId, slug))
+            assertThatThrownBy(() -> articleService.delete(userId, slug))
                 .isInstanceOf(ArticleNotFoundException.class);
         }
 

--- a/src/test/java/real/world/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/real/world/domain/follow/service/FollowServiceTest.java
@@ -1,0 +1,98 @@
+package real.world.domain.follow.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static real.world.fixture.UserFixtures.ALICE;
+import static real.world.fixture.UserFixtures.JOHN;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import real.world.domain.profile.dto.response.ProfileResponse;
+import real.world.domain.follow.entity.Follow;
+import real.world.domain.follow.repository.FollowRepository;
+import real.world.domain.user.entity.User;
+import real.world.domain.user.repository.UserRepository;
+import real.world.error.exception.UsernameNotExistException;
+
+class FollowServiceTest {
+
+    private final UserRepository userRepository = BDDMockito.mock(UserRepository.class);
+
+    private final FollowRepository followRepository = BDDMockito.mock(FollowRepository.class);
+
+    private final FollowService followService = new FollowService(userRepository, followRepository);
+
+    @Nested
+    class 팔로우_요청은 {
+
+        @Test
+        void 정상_호출시_팔로우를_하고_응답을_반환한다() {
+            // given
+            final User user = JOHN.생성();
+            final User follower = ALICE.생성();
+            given(userRepository.findByUsername(user.getUsername())).willReturn(Optional.of(user));
+            given(userRepository.findById(follower.getId())).willReturn(Optional.of(follower));
+            given(followRepository.existsByUserIdAndFollowerId(user.getId(), follower.getId())).willReturn(false);
+
+            // when
+            final ProfileResponse response = followService.follow(follower.getId(), user.getUsername());
+
+            // then
+            assertAll(() -> {
+                verify(followRepository).save(any(Follow.class));
+                assertThat(response.getUsername()).isEqualTo(user.getUsername());
+                assertThat(response.getBio()).isEqualTo(user.getBio());
+                assertThat(response.getImage()).isEqualTo(user.getImageUrl());
+                assertThat(response.isFollowing()).isEqualTo(true);
+            });
+        }
+
+        @Test
+        void 유저가_존재하지_않을_시_에외를_던진다() {
+            // given
+            final User user = JOHN.생성();
+            final User follower = ALICE.생성();
+            given(userRepository.findByUsername(user.getUsername())).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(
+                () -> followService.follow(follower.getId(), user.getUsername())
+            ).isInstanceOf(UsernameNotExistException.class);
+        }
+
+    }
+
+    @Nested
+    class 팔로우_취소_요청은 {
+
+        @Test
+        void 정상_호출시_팔로우를_취소하고_응답을_반환한다() {
+            // given
+            final User user = JOHN.생성();
+            final User follower = ALICE.생성();
+            given(userRepository.findByUsername(user.getUsername())).willReturn(Optional.of(user));
+            given(userRepository.findById(follower.getId())).willReturn(Optional.of(follower));
+            given(followRepository.existsByUserIdAndFollowerId(user.getId(), follower.getId())).willReturn(true);
+
+            // when
+            final ProfileResponse response = followService.unfollow(follower.getId(), user.getUsername());
+
+            // then
+            assertAll(() -> {
+                verify(followRepository).delete(any(Follow.class));
+                assertThat(response.getUsername()).isEqualTo(user.getUsername());
+                assertThat(response.getBio()).isEqualTo(user.getBio());
+                assertThat(response.getImage()).isEqualTo(user.getImageUrl());
+                assertThat(response.isFollowing()).isEqualTo(false);
+            });
+        }
+
+    }
+
+}

--- a/src/test/java/real/world/domain/profile/controller/ProfileControllerTest.java
+++ b/src/test/java/real/world/domain/profile/controller/ProfileControllerTest.java
@@ -1,0 +1,112 @@
+package real.world.domain.profile.controller;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static real.world.fixture.UserFixtures.ALICE;
+import static real.world.fixture.UserFixtures.JOHN;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import real.world.config.WebMvcConfig;
+import real.world.domain.follow.service.FollowService;
+import real.world.domain.profile.dto.response.ProfileResponse;
+import real.world.domain.profile.service.ProfileQueryService;
+import real.world.domain.user.entity.User;
+import real.world.support.TestSecurityConfig;
+import real.world.support.WithMockUserId;
+import real.world.support.WithMockUserIdFactory;
+
+@WebMvcTest(controllers = {ProfileController.class})
+@Import({TestSecurityConfig.class, WebMvcConfig.class, WithMockUserIdFactory.class})
+class ProfileControllerTest {
+
+    @MockBean
+    private FollowService followService;
+
+    @MockBean
+    private ProfileQueryService profileQueryService;
+
+    @Autowired
+    private MockMvc mockmvc;
+
+    @Nested
+    class 팔로우_요청 {
+
+        @Test
+        @WithMockUserId(user = ALICE)
+        void 상태코드_200로_성공() throws Exception {
+            // given
+            final User user = JOHN.생성();
+            given(followService.follow(anyLong(), anyString())).willReturn(
+                ProfileResponse.of(user, true));
+
+            // when
+            final ResultActions resultActions = mockmvc.perform(
+                post("/profiles/"+ user.getUsername() +"/follow"));
+
+            // then
+            resultActions.andExpect(status().isOk())
+                .andDo(print());
+            verify(followService).follow(anyLong(), anyString());
+        }
+
+    }
+
+    @Nested
+    class 팔로우_취소_요청 {
+
+        @Test
+        @WithMockUserId(user = ALICE)
+        void 상태코드_200로_성공() throws Exception {
+            // given
+            final User user = JOHN.생성();
+            given(followService.unfollow(anyLong(), anyString())).willReturn(ProfileResponse.of(user, false));
+
+            // when
+            final ResultActions resultActions = mockmvc.perform(
+                post("/profiles/"+ user.getUsername() +"/unfollow"));
+
+            // then
+            resultActions.andExpect(status().isOk())
+                .andDo(print());
+            verify(followService).unfollow(anyLong(), anyString());
+        }
+
+    }
+
+    @Nested
+    class 프로필_요청 {
+
+        @Test
+        @WithMockUserId(user = ALICE)
+        void 상태코드_200로_성공() throws Exception {
+            // given
+            final User user = JOHN.생성();
+            given(profileQueryService.getProfile(anyLong(), anyString())).willReturn(new ProfileResponse());
+
+            // when
+            final ResultActions resultActions = mockmvc.perform(
+                get("/profiles/"+ user.getUsername()));
+
+            // then
+            resultActions.andExpect(status().isOk())
+                .andDo(print());
+            verify(profileQueryService).getProfile(anyLong(), anyString());
+        }
+
+    }
+
+}

--- a/src/test/java/real/world/domain/profile/service/ProfileQueryServiceTest.java
+++ b/src/test/java/real/world/domain/profile/service/ProfileQueryServiceTest.java
@@ -1,0 +1,76 @@
+package real.world.domain.profile.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static real.world.fixture.UserFixtures.ALICE;
+import static real.world.fixture.UserFixtures.JOHN;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import real.world.domain.profile.dto.response.ProfileResponse;
+import real.world.domain.profile.repository.ProfileQueryRepository;
+import real.world.domain.user.dto.ProfileDto;
+import real.world.domain.user.entity.User;
+
+class ProfileQueryServiceTest {
+
+    private final ProfileQueryRepository profileQueryRepository = BDDMockito.mock(ProfileQueryRepository.class);
+
+    private final ProfileQueryService profileQueryService = new ProfileQueryService(profileQueryRepository);
+
+    @Nested
+    class 프로필_요청은 {
+
+        @Test
+        void 로그인이_되어있고_정상_호출시_프로필을_반환한다() {
+            // given
+            final User user = JOHN.생성();
+            final Long followerId = ALICE.생성().getId();
+            final ProfileDto profile = ProfileDto.of(user, true);
+            given(profileQueryRepository.findByLoginIdAndUsername(eq(followerId), eq(user.getUsername()))).willReturn(
+                Optional.of(profile));
+
+            // when
+            final ProfileResponse response = profileQueryService.getProfile(followerId, user.getUsername());
+
+            // then
+            assertAll(() -> {
+                verify(profileQueryRepository).findByLoginIdAndUsername(anyLong(), anyString());
+                assertThat(response.getUsername()).isEqualTo(user.getUsername());
+                assertThat(response.getBio()).isEqualTo(user.getBio());
+                assertThat(response.getImage()).isEqualTo(user.getImageUrl());
+                assertThat(response.isFollowing()).isEqualTo(true);
+            });
+        }
+
+        @Test
+        void 로그인이_되어있지_않고_정상_호출시_프로필을_반환한다() {
+            // given
+            final User user = JOHN.생성();
+            final Long notExistId = 0L;
+            final ProfileDto profile = ProfileDto.of(user, false);
+            given(profileQueryRepository.findByLoginIdAndUsername(eq(notExistId), eq(user.getUsername()))).willReturn(
+                Optional.of(profile));
+
+            // when
+            final ProfileResponse response = profileQueryService.getProfile(notExistId, user.getUsername());
+
+            // then
+            assertAll(() -> {
+                verify(profileQueryRepository).findByLoginIdAndUsername(anyLong(), anyString());
+                assertThat(response.getUsername()).isEqualTo(user.getUsername());
+                assertThat(response.getBio()).isEqualTo(user.getBio());
+                assertThat(response.getImage()).isEqualTo(user.getImageUrl());
+                assertThat(response.isFollowing()).isEqualTo(false);
+            });
+        }
+
+    }
+}

--- a/src/test/java/real/world/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/real/world/domain/user/controller/UserControllerTest.java
@@ -101,7 +101,7 @@ public class UserControllerTest {
 
         @Test
         @WithMockUserId(user = JOHN)
-        void 상태코드_201로_성공() throws Exception {
+        void 상태코드_200로_성공() throws Exception {
             // given
             final User user = JOHN.생성();
             final Long id = JOHN.getId();
@@ -111,7 +111,7 @@ public class UserControllerTest {
             final ResultActions resultActions = mockmvc.perform(get("/user"));
 
             // then
-            resultActions.andExpect(status().isCreated())
+            resultActions.andExpect(status().isOk())
                 .andDo(print());
             verify(userService).getUser(any());
         }
@@ -149,7 +149,7 @@ public class UserControllerTest {
                 .content(objectMapper.writeValueAsString(new UpdateRequest())));
 
             // then
-            resultActions.andExpect(status().isCreated())
+            resultActions.andExpect(status().isOk())
                 .andDo(print());
             verify(userService).update(anyLong(), any(UpdateRequest.class));
         }
@@ -170,24 +170,6 @@ public class UserControllerTest {
             resultActions.andExpect(status().isUnprocessableEntity())
                 .andDo(print());
             verify(userService).update(anyLong(), any(UpdateRequest.class));
-        }
-
-    }
-
-    @Nested
-    class 프로필조회 {
-
-        // TODO 일단 테스트 API로 작성하였으니 추후에 구현후 수정할 것
-        @Test
-        @WithMockUserId(user = JOHN)
-        void 상태코드_200으로_성공() throws Exception {
-            // given & when
-            final ResultActions resultActions = mockmvc.perform(
-                get("/profiles"));
-
-            // then
-            resultActions.andExpect(status().isCreated())
-                .andDo(print());
         }
 
     }

--- a/src/test/java/real/world/domain/user/service/UserServiceTest.java
+++ b/src/test/java/real/world/domain/user/service/UserServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.BDDMockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import real.world.domain.follow.repository.FollowRepository;
 import real.world.domain.user.dto.request.RegisterRequest;
 import real.world.domain.user.dto.request.UpdateRequest;
 import real.world.domain.user.dto.response.UserResponse;

--- a/src/test/java/real/world/e2e/ArticleE2ETest.java
+++ b/src/test/java/real/world/e2e/ArticleE2ETest.java
@@ -2,8 +2,12 @@ package real.world.e2e;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static real.world.e2e.RestAssuredUtils.로그인_상태로_GET_요청을_보낸다;
 import static real.world.e2e.RestAssuredUtils.로그인_상태로_POST_요청을_보낸다;
+import static real.world.e2e.RestAssuredUtils.로그인_상태로_PUT_요청을_보낸다;
+import static real.world.e2e.RestAssuredUtils.로그인_상태로_DELETE_요청을_보낸다;
 import static real.world.fixture.ArticleFixtures.게시물;
+import static real.world.fixture.ArticleFixtures.게시물_2;
 import static real.world.fixture.UserFixtures.JOHN;
 
 import io.restassured.response.ExtractableResponse;
@@ -11,6 +15,7 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import real.world.domain.article.dto.request.ArticleUpdateRequest;
 import real.world.domain.article.dto.request.UploadRequest;
 import real.world.domain.article.dto.response.ArticleResponse;
 import real.world.e2e.util.DBInitializer;
@@ -38,6 +43,58 @@ public class ArticleE2ETest extends E2ETest {
             assertThat(response.getDescription()).isEqualTo(게시물.getDescription());
             assertThat(response.getBody()).isEqualTo(게시물.getBody());
         });
+    }
+
+    @Test
+    void 게시물을_조회_한다() {
+        // given
+        dbInitializer.게시물이_하나_업로드_돼있다();
+
+        // when
+        final ExtractableResponse<Response> extractableResponse = 로그인_상태로_GET_요청을_보낸다(
+            JOHN, "/articles/" + 게시물.getSlug());
+        final ArticleResponse response = extractableResponse.as(ArticleResponse.class);
+
+        // then
+        assertAll(() -> {
+            assertThat(extractableResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertThat(response.getTitle()).isEqualTo(게시물.getTitle());
+            assertThat(response.getDescription()).isEqualTo(게시물.getDescription());
+            assertThat(response.getBody()).isEqualTo(게시물.getBody());
+        });
+    }
+
+    @Test
+    void 게시물을_수정_한다() {
+        // given
+        dbInitializer.게시물이_하나_업로드_돼있다();
+        final ArticleUpdateRequest request = 게시물_2.수정을_한다();
+
+        // when
+        final ExtractableResponse<Response> extractableResponse = 로그인_상태로_PUT_요청을_보낸다(
+            JOHN, "/articles/" + 게시물.getSlug(), request);
+        final ArticleResponse response = extractableResponse.as(ArticleResponse.class);
+
+        // then
+        assertAll(() -> {
+            assertThat(extractableResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertThat(response.getTitle()).isEqualTo(게시물_2.getTitle());
+            assertThat(response.getDescription()).isEqualTo(게시물_2.getDescription());
+            assertThat(response.getBody()).isEqualTo(게시물_2.getBody());
+        });
+    }
+    
+    @Test
+    void 게시물을_삭제_한다() {
+        // given
+        dbInitializer.게시물이_하나_업로드_돼있다();
+
+        // when
+        final ExtractableResponse<Response> extractableResponse = 로그인_상태로_DELETE_요청을_보낸다(
+            JOHN, "/articles/" + 게시물.getSlug());
+
+        // then
+        assertThat(extractableResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
 }

--- a/src/test/java/real/world/e2e/RestAssuredUtils.java
+++ b/src/test/java/real/world/e2e/RestAssuredUtils.java
@@ -60,12 +60,10 @@ public class RestAssuredUtils {
             .extract();
     }
 
-    public static ExtractableResponse<Response> 로그인_상태로_DELETE_요청을_보낸다(UserFixtures user, String url,
-        Object body) {
+    public static ExtractableResponse<Response> 로그인_상태로_DELETE_요청을_보낸다(UserFixtures user, String url) {
         final String token = 로그인_요청을_보낸다(user);
         return RestAssured
             .given().log().all()
-            .contentType(MediaType.APPLICATION_JSON_VALUE).body(body)
             .header("Authorization", token)
             .when().delete(url)
             .then().log().all()

--- a/src/test/java/real/world/e2e/RestAssuredUtils.java
+++ b/src/test/java/real/world/e2e/RestAssuredUtils.java
@@ -48,6 +48,30 @@ public class RestAssuredUtils {
             .extract();
     }
 
+    public static ExtractableResponse<Response> 로그인_상태로_PUT_요청을_보낸다(UserFixtures user, String url,
+        Object body) {
+        final String token = 로그인_요청을_보낸다(user);
+        return RestAssured
+            .given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE).body(body)
+            .header("Authorization", token)
+            .when().put(url)
+            .then().log().all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> 로그인_상태로_DELETE_요청을_보낸다(UserFixtures user, String url,
+        Object body) {
+        final String token = 로그인_요청을_보낸다(user);
+        return RestAssured
+            .given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE).body(body)
+            .header("Authorization", token)
+            .when().delete(url)
+            .then().log().all()
+            .extract();
+    }
+
     private static String 로그인_요청을_보낸다(UserFixtures user) {
         final LoginRequest request = user.로그인을_한다();
         return RestAssured

--- a/src/test/java/real/world/e2e/util/DBInitializer.java
+++ b/src/test/java/real/world/e2e/util/DBInitializer.java
@@ -8,6 +8,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import real.world.fixture.ArticleFixtures;
 
 @Component
 public class DBInitializer {
@@ -20,6 +21,20 @@ public class DBInitializer {
         entityManager.persist(JOHN.지정된_ID로_생성(null));
         entityManager.persist(BOB.지정된_ID로_생성(null));
         entityManager.persist(ALICE.지정된_ID로_생성(null));
+    }
+
+    @Transactional
+    public void 게시물이_하나_업로드_돼있다() {
+        유저들이_회원가입_돼있다();
+        entityManager.persist(ArticleFixtures.게시물.생성(JOHN.getId()));
+    }
+    
+    @Transactional
+    public void 게시물이_업로드_돼있다() {
+        유저들이_회원가입_돼있다();
+        entityManager.persist(ArticleFixtures.게시물.생성(JOHN.getId()));
+        entityManager.persist(ArticleFixtures.게시물_2.생성(JOHN.getId()));
+        entityManager.persist(ArticleFixtures.게시물_3.생성(JOHN.getId()));
     }
 
 }

--- a/src/test/java/real/world/fixture/ArticleFixtures.java
+++ b/src/test/java/real/world/fixture/ArticleFixtures.java
@@ -8,12 +8,16 @@ import org.springframework.test.util.ReflectionTestUtils;
 import real.world.domain.article.dto.request.UploadRequest;
 import real.world.domain.article.entity.Article;
 import real.world.domain.article.query.ArticleView;
+import real.world.domain.article.service.SlugTranslator;
 import real.world.domain.user.entity.User;
+import real.world.support.StubSlugTranslator;
 
 @Getter
 public enum ArticleFixtures {
 
-    게시물("title", "slug", "desc", "body", Collections.emptyList());
+    게시물("title", "title", "desc", "body", Collections.emptyList());
+
+    private static final SlugTranslator TRANSLATOR = new StubSlugTranslator();
 
     private final String title;
 
@@ -37,7 +41,7 @@ public enum ArticleFixtures {
         return new Article(
             user,
             this.title,
-            this.slug,
+            TRANSLATOR,
             this.description,
             this.body,
             this.tags
@@ -48,7 +52,7 @@ public enum ArticleFixtures {
         return new Article(
             user,
             this.title,
-            this.slug,
+            TRANSLATOR,
             this.description,
             this.body,
             tags

--- a/src/test/java/real/world/fixture/ArticleFixtures.java
+++ b/src/test/java/real/world/fixture/ArticleFixtures.java
@@ -9,7 +9,6 @@ import real.world.domain.article.dto.request.UploadRequest;
 import real.world.domain.article.entity.Article;
 import real.world.domain.article.query.ArticleView;
 import real.world.domain.article.service.SlugTranslator;
-import real.world.domain.user.entity.User;
 import real.world.support.StubSlugTranslator;
 
 @Getter
@@ -37,9 +36,9 @@ public enum ArticleFixtures {
         this.tags = tags;
     }
 
-    public Article 생성(User user) {
+    public Article 생성(Long userId) {
         return new Article(
-            user,
+            userId,
             this.title,
             TRANSLATOR,
             this.description,
@@ -48,9 +47,9 @@ public enum ArticleFixtures {
         );
     }
 
-    public Article 태그와_함께_생성(User user, Set<String> tags) {
+    public Article 태그와_함께_생성(Long userId, Set<String> tags) {
         return new Article(
-            user,
+            userId,
             this.title,
             TRANSLATOR,
             this.description,
@@ -59,9 +58,9 @@ public enum ArticleFixtures {
         );
     }
 
-    public ArticleView 뷰_생성(User user) {
+    public ArticleView 뷰_생성(Long userId) {
         return new ArticleView(
-            생성(user),
+            생성(userId),
             false,
             0
         );

--- a/src/test/java/real/world/fixture/ArticleFixtures.java
+++ b/src/test/java/real/world/fixture/ArticleFixtures.java
@@ -16,7 +16,8 @@ import real.world.support.StubSlugTranslator;
 public enum ArticleFixtures {
 
     게시물("title", "title", "desc", "body", Collections.emptyList()),
-    게시물_2("title2", "title2", "desc2", "body2", Collections.emptyList());
+    게시물_2("title2", "title2", "desc2", "body2", Collections.emptyList()),
+    게시물_3("title3", "title3", "desc3", "body3", Collections.emptyList());
 
     private static final SlugTranslator TRANSLATOR = new StubSlugTranslator();
 

--- a/src/test/java/real/world/fixture/ArticleFixtures.java
+++ b/src/test/java/real/world/fixture/ArticleFixtures.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Set;
 import lombok.Getter;
 import org.springframework.test.util.ReflectionTestUtils;
+import real.world.domain.article.dto.request.ArticleUpdateRequest;
 import real.world.domain.article.dto.request.UploadRequest;
 import real.world.domain.article.entity.Article;
 import real.world.domain.article.query.ArticleView;
@@ -14,7 +15,8 @@ import real.world.support.StubSlugTranslator;
 @Getter
 public enum ArticleFixtures {
 
-    게시물("title", "title", "desc", "body", Collections.emptyList());
+    게시물("title", "title", "desc", "body", Collections.emptyList()),
+    게시물_2("title2", "title2", "desc2", "body2", Collections.emptyList());
 
     private static final SlugTranslator TRANSLATOR = new StubSlugTranslator();
 
@@ -81,6 +83,14 @@ public enum ArticleFixtures {
         ReflectionTestUtils.setField(request, "description", this.description);
         ReflectionTestUtils.setField(request, "body", this.body);
         ReflectionTestUtils.setField(request, "tags", tags);
+        return request;
+    }
+
+    public ArticleUpdateRequest 수정을_한다() {
+        final ArticleUpdateRequest request = new ArticleUpdateRequest();
+        ReflectionTestUtils.setField(request, "title", this.title);
+        ReflectionTestUtils.setField(request, "description", this.description);
+        ReflectionTestUtils.setField(request, "body", this.body);
         return request;
     }
 

--- a/src/test/java/real/world/support/StubSlugTranslator.java
+++ b/src/test/java/real/world/support/StubSlugTranslator.java
@@ -1,0 +1,12 @@
+package real.world.support;
+
+import real.world.domain.article.service.SlugTranslator;
+
+public class StubSlugTranslator implements SlugTranslator {
+
+    @Override
+    public String translate(String title) {
+        return title.toLowerCase().replaceAll("\\s+", "-");
+    }
+
+}

--- a/src/test/java/real/world/support/TestConfig.java
+++ b/src/test/java/real/world/support/TestConfig.java
@@ -1,0 +1,17 @@
+package real.world.support;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import real.world.domain.article.service.SlugTranslator;
+
+@TestConfiguration
+@Primary
+public class TestConfig {
+
+    @Bean
+    public SlugTranslator slugTranslator() {
+        return new StubSlugTranslator();
+    }
+
+}

--- a/src/test/java/real/world/support/TestSecurityConfig.java
+++ b/src/test/java/real/world/support/TestSecurityConfig.java
@@ -21,6 +21,8 @@ public class TestSecurityConfig {
 
     private static final String[] AUTH_PATH = {"/users", LOGIN_PATH};
 
+    private static final String[]  OPTIONAL_PATH = {"/profiles/*"};
+
     private static final String[] SWAGGER_PATH = {"/docs/open-api.json", "/swagger-ui/**",
         "/v3/**"};
 
@@ -33,6 +35,7 @@ public class TestSecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.POST, AUTH_PATH).permitAll()
                 .requestMatchers(HttpMethod.GET, SWAGGER_PATH).permitAll()
+                .requestMatchers(HttpMethod.GET, OPTIONAL_PATH).permitAll()
                 .anyRequest().hasRole("USER")
             )
             .sessionManagement(


### PR DESCRIPTION
##  📣요약
- 아티클 조회, 삭제, 수정 API 구현
  - [x] 테스트 작성
- SlugTranslator 관련 변경
- 도메인 간 참조 수정
## ✨ 세부 내용
### 아티클관련 API 구현
- 조회, 삭제, 수정 로직 구현
- `Article` 수정, 삭제 시엔 본인이 올린 아티클인지 검사하는 로직이 필요
  - `Article`내 메서드`verifyUserid()`의` 파라매터로 현재 로그인 한 사용자를 받아 검증함
  -  API Spec엔 없으나 `ROLE_ADMIN`인 경우는 어떻게 처리해야할지에 대한 고민 필요.
- 각 로직에 대해 테스트 작성 완료 
### SlugTransloatr 관련 변경
- 정상 동작하지 않고 있던 `UUIDSlugTranslator` 고침
- `Article`내에서 `SlugTranslator`를 파라매터로 받아 처리로직을 호출하도록 변경
  - 스프링 빈(Translator)을 파라매터로 넘겨 도메인 엔티티 내부에서 메서드 호출하는게 응집성이 더 높다고 판단헀음
  - `SlugTranslator`는 사실 `service` 패키지가 아니라 `domain`패키지(기존의 entity+repository)에 속하고, `UUDSlugTranslator`는 세부사항으로 `infra`와 같은 패키지에 속해야함
### 도메인 간 참조 수정
- 객체 참조와 ID 참조를 둘 다 혼용함
- 객체 참조는 `Article`-`Tag`관계 처럼 함께 생성,소멸,변경 되는 매우 밀접한 관계일때만 사용하기로 함
- ID 참조는 위 조건 외의 경우에 전부 사용함.
- 현재는 Article 관련 객체(Comment, Favorite)에만 적용하였고, 나머지 객체도 필요하다고 생각하면 적용