### PR TITLE
[Feature] 아티클 피드 조회 구현, 아티클에 프로필 추가

### DIFF
--- a/http/article.http
+++ b/http/article.http
@@ -4,8 +4,8 @@ Content-Type: application/json
 
 {
   "user": {
-    "username": "username",
-    "email": "eee@email.com",
+    "username": {{username}},
+    "email": {{email}},
     "password": "1234"
   }
 }
@@ -16,7 +16,7 @@ Content-Type: application/json
 
 {
   "user": {
-    "email": "eee@email.com",
+    "email": {{email}},
     "password": "1234"
   }
 }
@@ -81,3 +81,11 @@ Content-Type: application/json
 DELETE {{domain}}/api/articles/{{slug}}
 Authorization: {{access_token}}
 Content-Type: application/json
+
+### 팔로우
+POST {{domain}}/api/profiles/{{target}}/follow
+Authorization: {{access_token}}
+
+### 아티클 피드 조회
+GET {{domain}}/api/articles/feed?offset=0&limit=10
+Authorization: {{access_token}}

--- a/http/article.http
+++ b/http/article.http
@@ -86,6 +86,18 @@ Content-Type: application/json
 POST {{domain}}/api/profiles/{{target}}/follow
 Authorization: {{access_token}}
 
-### 아티클 피드 조회
+### 아티클 팔로우 피드 조회
 GET {{domain}}/api/articles/feed?offset=0&limit=10
+Authorization: {{access_token}}
+
+### 아티클 Global 조회
+GET {{domain}}/api/articles?offset=0&limit=10
+Authorization: {{access_token}}
+
+### 아티클 Global Author 조건 조회
+GET {{domain}}/api/articles?offset=0&limit=10&author={{target}}
+Authorization: {{access_token}}
+
+### 아티클 Global tag 조건 조회
+GET {{domain}}/api/articles?offset=0&limit=10&tag=tag1
 Authorization: {{access_token}}

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,6 +1,15 @@
 {
-  "local": {
-    "domain": "localhost:8080"
+  "username": {
+    "domain": "localhost:8080",
+    "username": "\"username2\"",
+    "email": "\"eee@email.com\"",
+    "target": "username1"
+  },
+  "username1": {
+    "domain": "localhost:8080",
+    "username": "\"username1\"",
+    "email": "\"eee2@email.com\"",
+    "target": "username2"
   },
   "server": {
     "domian": ""

--- a/src/main/java/real/world/config/WebMvcConfig.java
+++ b/src/main/java/real/world/config/WebMvcConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import real.world.domain.auth.annotation.AuthArgumentResolver;
+import real.world.domain.global.PageArgumentResolver;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
@@ -12,6 +13,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new AuthArgumentResolver());
+        resolvers.add(new PageArgumentResolver());
     }
 
 }

--- a/src/main/java/real/world/domain/article/controller/ArticleController.java
+++ b/src/main/java/real/world/domain/article/controller/ArticleController.java
@@ -1,6 +1,7 @@
 package real.world.domain.article.controller;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,9 +15,11 @@ import real.world.domain.article.dto.request.ArticleUpdateRequest;
 import real.world.domain.article.dto.request.UploadRequest;
 import real.world.domain.article.dto.response.ArticleApiResponse;
 import real.world.domain.article.dto.response.ArticleResponse;
+import real.world.domain.article.dto.response.ArticlesApiResponse;
 import real.world.domain.article.service.ArticleQueryService;
 import real.world.domain.article.service.ArticleService;
 import real.world.domain.auth.annotation.Auth;
+import real.world.domain.global.Page;
 
 @RestController
 public class ArticleController {
@@ -29,6 +32,12 @@ public class ArticleController {
         ArticleQueryService articleQueryService) {
         this.articleService = articleService;
         this.articleQueryService = articleQueryService;
+    }
+
+    @GetMapping("/articles/feed")
+    public ResponseEntity<ArticlesApiResponse> getArticleFeed(@Auth Long loginId, Page page) {
+        List<ArticleResponse> responses = articleQueryService.getArticles(loginId, page);
+        return new ResponseEntity<>(new ArticlesApiResponse(responses), HttpStatus.OK);
     }
 
     @PostMapping("/articles")

--- a/src/main/java/real/world/domain/article/controller/ArticleController.java
+++ b/src/main/java/real/world/domain/article/controller/ArticleController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import real.world.domain.article.dto.request.ArticleUpdateRequest;
 import real.world.domain.article.dto.request.UploadRequest;
@@ -37,6 +38,15 @@ public class ArticleController {
     @GetMapping("/articles/feed")
     public ResponseEntity<ArticlesApiResponse> getArticleFeed(@Auth Long loginId, Page page) {
         List<ArticleResponse> responses = articleQueryService.getArticles(loginId, page);
+        return new ResponseEntity<>(new ArticlesApiResponse(responses), HttpStatus.OK);
+    }
+
+    @GetMapping("/articles")
+    public ResponseEntity<ArticlesApiResponse> getRecentArticles(@Auth Long loginId, Page page,
+        @RequestParam(required = false) String tag,
+        @RequestParam(required = false) String author,
+        @RequestParam(required = false) String favorited) {
+        List<ArticleResponse> responses = articleQueryService.getRecent(loginId, page, tag, author, favorited);
         return new ResponseEntity<>(new ArticlesApiResponse(responses), HttpStatus.OK);
     }
 

--- a/src/main/java/real/world/domain/article/dto/response/ArticleResponse.java
+++ b/src/main/java/real/world/domain/article/dto/response/ArticleResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import real.world.domain.article.query.ArticleView;
+import real.world.domain.profile.dto.response.ProfileResponse;
 import real.world.domain.profile.query.Profile;
 
 @Getter
@@ -21,7 +22,7 @@ public class ArticleResponse {
     private boolean favorited;
     private long favoritesCount;
 
-    private Profile author;
+    private ProfileResponse author;
 
     private ArticleResponse(String slug, String title, String description, String body,
         List<String> tagList, LocalDateTime createdAt, LocalDateTime updatedAt, boolean favorited,
@@ -35,7 +36,7 @@ public class ArticleResponse {
         this.updatedAt = updatedAt;
         this.favorited = favorited;
         this.favoritesCount = favoritesCount;
-        this.author = author;
+        this.author = ProfileResponse.of(author);
     }
 
     public static ArticleResponse of(ArticleView article) {
@@ -43,7 +44,7 @@ public class ArticleResponse {
             article.getSlug(), article.getTitle(), article.getDescription(),
             article.getBody(), article.getTagList(), article.getCreatedAt(),
             article.getUpdatedAt(), article.isFavorited(), article.getFavoritesCount(),
-            null // TODO
+            article.getProfile()
         );
     }
 

--- a/src/main/java/real/world/domain/article/dto/response/ArticlesApiResponse.java
+++ b/src/main/java/real/world/domain/article/dto/response/ArticlesApiResponse.java
@@ -1,0 +1,20 @@
+package real.world.domain.article.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ArticlesApiResponse {
+
+    private List<ArticleResponse> articles;
+
+    private int articlesCount;
+
+    public ArticlesApiResponse(List<ArticleResponse> articles) {
+        this.articles = articles;
+        this.articlesCount = articles.size();
+    }
+
+}

--- a/src/main/java/real/world/domain/article/query/ArticleQueryRepository.java
+++ b/src/main/java/real/world/domain/article/query/ArticleQueryRepository.java
@@ -1,10 +1,14 @@
 package real.world.domain.article.query;
 
+import java.util.List;
 import java.util.Optional;
+import real.world.domain.global.Page;
 
-public interface ArticleQueryRepository{
+public interface ArticleQueryRepository {
 
     Optional<ArticleView> findById(Long loginId, Long id);
+
+    List<ArticleView> findByLoginId(Long loginId, Page page);
 
     Optional<ArticleView> findBySlug(Long loginId, String slug);
 

--- a/src/main/java/real/world/domain/article/query/ArticleQueryRepository.java
+++ b/src/main/java/real/world/domain/article/query/ArticleQueryRepository.java
@@ -10,6 +10,8 @@ public interface ArticleQueryRepository {
 
     List<ArticleView> findByLoginId(Long loginId, Page page);
 
+    List<ArticleView> findRecent(Long loginId, Page page, String tag, String author, String favorited);
+
     Optional<ArticleView> findBySlug(Long loginId, String slug);
 
 }

--- a/src/main/java/real/world/domain/article/query/ArticleQueryRepositoryImpl.java
+++ b/src/main/java/real/world/domain/article/query/ArticleQueryRepositoryImpl.java
@@ -28,7 +28,7 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
 
     @Override
     public Optional<ArticleView> findById(Long loginId, Long id) {
-        return Optional.ofNullable(factory.select(new QArticleView(
+        return Optional.ofNullable(factory.select(Projections.constructor(ArticleView.class,
                 article,
                 JPAExpressions.selectFrom(favorite)
                     .where(favorite.userId.eq(loginId).and(favorite.articleId.eq(id)))

--- a/src/main/java/real/world/domain/article/query/ArticleQueryRepositoryImpl.java
+++ b/src/main/java/real/world/domain/article/query/ArticleQueryRepositoryImpl.java
@@ -2,11 +2,15 @@ package real.world.domain.article.query;
 
 import static real.world.domain.article.entity.QArticle.article;
 import static real.world.domain.article.entity.QFavorite.favorite;
+import static real.world.domain.follow.entity.QFollow.follow;
 
 import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Repository;
+import real.world.domain.global.Page;
 
 @Repository
 public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
@@ -20,14 +24,43 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
     @Override
     public Optional<ArticleView> findById(Long loginId, Long id) {
         return Optional.ofNullable(factory.select(new QArticleView(
-            article,
-            JPAExpressions.selectFrom(favorite)
-                .where(favorite.userId.eq(loginId).and(favorite.articleId.eq(id)))
-                .exists(),
-            JPAExpressions.select(favorite.count())
-                .from(favorite)
-                .where(favorite.articleId.eq(id))
-        )).from(article).where(article.id.eq(id)).fetchOne());
+                article,
+                JPAExpressions.selectFrom(favorite)
+                    .where(favorite.userId.eq(loginId).and(favorite.articleId.eq(id)))
+                    .exists(),
+                JPAExpressions.select(favorite.count())
+                    .from(favorite)
+                    .where(favorite.articleId.eq(id))
+            ))
+            .from(article)
+            .where(article.id.eq(id))
+            .fetchOne());
+    }
+
+    @Override
+    public List<ArticleView> findByLoginId(Long loginId, Page page) {
+        return factory.select(new QArticleView(
+                article,
+                JPAExpressions.selectFrom(favorite)
+                    .where(favorite.userId.eq(loginId).and(favorite.articleId.eq(article.id)))
+                    .exists(),
+                JPAExpressions.select(favorite.count())
+                    .from(favorite)
+                    .where(favorite.articleId.eq(article.id))
+            ))
+            .from(article)
+            .where(article.userId.in(JPAExpressions.select(follow.user.id)
+                .from(follow)
+                .where(follow.follower.id.eq(loginId))))
+            .offset(page.getOffset())
+            .limit(page.getLimit())
+            .fetch();
+    }
+
+    private JPQLQuery<Long> findFollowingUserIds(Long loginId) {
+        return JPAExpressions.select(follow.follower.id)
+            .from(follow)
+            .where(follow.user.id.eq(loginId));
     }
 
     @Override
@@ -38,5 +71,6 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
             .fetchOne();
         return findById(loginId, id);
     }
+
 
 }

--- a/src/main/java/real/world/domain/article/query/ArticleQueryRepositoryImpl.java
+++ b/src/main/java/real/world/domain/article/query/ArticleQueryRepositoryImpl.java
@@ -3,16 +3,21 @@ package real.world.domain.article.query;
 import static real.world.domain.article.entity.QArticle.article;
 import static real.world.domain.article.entity.QFavorite.favorite;
 import static real.world.domain.follow.entity.QFollow.follow;
+import static real.world.domain.user.entity.QUser.user;
 
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import real.world.domain.global.Page;
 
 @Repository
+@Slf4j
 public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
 
     private final JPAQueryFactory factory;
@@ -39,7 +44,7 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
 
     @Override
     public List<ArticleView> findByLoginId(Long loginId, Page page) {
-        return factory.select(new QArticleView(
+        return factory.select(Projections.constructor(ArticleView.class,
                 article,
                 JPAExpressions.selectFrom(favorite)
                     .where(favorite.userId.eq(loginId).and(favorite.articleId.eq(article.id)))
@@ -49,18 +54,65 @@ public class ArticleQueryRepositoryImpl implements ArticleQueryRepository {
                     .where(favorite.articleId.eq(article.id))
             ))
             .from(article)
-            .where(article.userId.in(JPAExpressions.select(follow.user.id)
-                .from(follow)
-                .where(follow.follower.id.eq(loginId))))
+            .where(article.userId.in(findFollowingUserIds(loginId)))
             .offset(page.getOffset())
             .limit(page.getLimit())
             .fetch();
     }
 
     private JPQLQuery<Long> findFollowingUserIds(Long loginId) {
-        return JPAExpressions.select(follow.follower.id)
+        return JPAExpressions.select(follow.user.id)
             .from(follow)
-            .where(follow.user.id.eq(loginId));
+            .where(follow.follower.id.eq(loginId));
+    }
+
+    @Override
+    public List<ArticleView> findRecent(Long loginId, Page page, String tag, String author,
+        String favorited) {
+        return factory.select(Projections.constructor(ArticleView.class,
+                article,
+                JPAExpressions.selectFrom(favorite)
+                    .where(favorite.userId.eq(loginId).and(favorite.articleId.eq(article.id)))
+                    .exists(),
+                JPAExpressions.select(favorite.count())
+                    .from(favorite)
+                    .where(favorite.articleId.eq(article.id))
+            ))
+            .from(article)
+            .where(eqAuthor(author), hasTag(tag), isFavorited(favorited))
+            .offset(page.getOffset())
+            .limit(page.getLimit())
+            .fetch();
+    }
+
+    private BooleanExpression eqAuthor(String author) {
+        if (author == null) {
+            return null;
+        }
+        final Long authorId = factory.select(user.id)
+            .from(user)
+            .where(user.username.eq(author))
+            .fetchFirst();
+        return authorId == null ? null : article.userId.eq(authorId);
+    }
+
+    private BooleanExpression hasTag(String tag) {
+        return tag == null ? null : article.tags.contains(tag);
+    }
+
+    private BooleanExpression isFavorited(String favorited) {
+        if (favorited == null) {
+            return null;
+        }
+        final List<Long> favoriteArticleIds = factory.select(favorite.articleId)
+            .from(favorite)
+            .innerJoin(user).on(user.id.eq(favorite.userId))
+            .where(user.username.eq(favorited))
+            .fetch();
+        if(favoriteArticleIds.isEmpty()) {
+            return null;
+        }
+        return article.id.in(favoriteArticleIds);
     }
 
     @Override

--- a/src/main/java/real/world/domain/article/query/ArticleView.java
+++ b/src/main/java/real/world/domain/article/query/ArticleView.java
@@ -1,11 +1,11 @@
 package real.world.domain.article.query;
 
-import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import real.world.domain.article.entity.Article;
+import real.world.domain.profile.query.Profile;
 
 @Getter
 @NoArgsConstructor
@@ -29,7 +29,9 @@ public class ArticleView {
 
     private long favoritesCount;
 
-    // TODO profile
+    private Long userId;
+
+    private Profile profile;
 
     public ArticleView(Article article, boolean favorited, long favoritesCount) {
         this.title = article.getTitle();
@@ -41,6 +43,11 @@ public class ArticleView {
         this.updatedAt = article.getUpdatedAt();
         this.favorited = favorited;
         this.favoritesCount = favoritesCount;
+        this.userId = article.getUserId();
+    }
+
+    public void setProfile(Profile profile) {
+        this.profile = profile;
     }
 
 }

--- a/src/main/java/real/world/domain/article/query/ArticleView.java
+++ b/src/main/java/real/world/domain/article/query/ArticleView.java
@@ -31,7 +31,6 @@ public class ArticleView {
 
     // TODO profile
 
-    @QueryProjection
     public ArticleView(Article article, boolean favorited, long favoritesCount) {
         this.title = article.getTitle();
         this.slug = article.getSlug();

--- a/src/main/java/real/world/domain/article/service/ArticleQueryService.java
+++ b/src/main/java/real/world/domain/article/service/ArticleQueryService.java
@@ -1,10 +1,12 @@
 package real.world.domain.article.service;
 
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import real.world.domain.article.dto.response.ArticleResponse;
 import real.world.domain.article.query.ArticleQueryRepository;
 import real.world.domain.article.query.ArticleView;
+import real.world.domain.global.Page;
 import real.world.error.exception.ArticleNotFoundException;
 
 @Service
@@ -27,6 +29,11 @@ public class ArticleQueryService {
         final ArticleView articleView = articleQueryRepository.findBySlug(loginId, slug)
             .orElseThrow(ArticleNotFoundException::new);
         return ArticleResponse.of(articleView);
+    }
+
+    public List<ArticleResponse> getArticles(Long loginId, Page page) {
+        final List<ArticleView> articleView = articleQueryRepository.findByLoginId(loginId, page);
+        return articleView.stream().map(ArticleResponse::of).toList();
     }
 
 }

--- a/src/main/java/real/world/domain/article/service/ArticleQueryService.java
+++ b/src/main/java/real/world/domain/article/service/ArticleQueryService.java
@@ -36,4 +36,11 @@ public class ArticleQueryService {
         return articleView.stream().map(ArticleResponse::of).toList();
     }
 
+    public List<ArticleResponse> getRecent(Long loginId, Page page, String tag, String author,
+        String favorited) {
+        final List<ArticleView> articleView = articleQueryRepository.findRecent(loginId, page, tag,
+            author, favorited);
+        return articleView.stream().map(ArticleResponse::of).toList();
+    }
+
 }

--- a/src/main/java/real/world/domain/global/Page.java
+++ b/src/main/java/real/world/domain/global/Page.java
@@ -1,0 +1,17 @@
+package real.world.domain.global;
+
+import lombok.Getter;
+
+@Getter
+public class Page {
+
+    private final int offset;
+
+    private final int limit;
+
+    public Page(int offset, int limit) {
+        this.offset = offset;
+        this.limit = limit;
+    }
+
+}

--- a/src/main/java/real/world/domain/global/PageArgumentResolver.java
+++ b/src/main/java/real/world/domain/global/PageArgumentResolver.java
@@ -1,0 +1,51 @@
+package real.world.domain.global;
+
+import jakarta.annotation.Nonnull;
+import java.util.regex.Pattern;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import real.world.error.exception.RequestInvalidException;
+
+public class PageArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final int MAX_LIMIT = 30;
+    private static final Pattern NUMBER = Pattern.compile("^[0-9]*$");
+
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(Page.class);
+    }
+
+    @Override
+    public Object resolveArgument(@Nonnull MethodParameter parameter,
+        ModelAndViewContainer mavContainer,
+        @Nonnull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        final String offsetArgument = webRequest.getParameter("offset");
+        final String limitArgument = webRequest.getParameter("limit");
+        return new Page(verifyAndConvertOffset(offsetArgument),
+            verifyAndConvertLimit(limitArgument));
+    }
+
+    private int verifyAndConvertOffset(String offset) {
+        if (offset == null || !NUMBER.matcher(offset).matches()) {
+            throw new RequestInvalidException();
+        }
+        return Integer.parseInt(offset);
+    }
+
+    private int verifyAndConvertLimit(String limit) {
+        if (limit == null || !NUMBER.matcher(limit).matches()) {
+            throw new RequestInvalidException();
+        }
+        final int parsedLimit = Integer.parseInt(limit);
+        if (parsedLimit > MAX_LIMIT) {
+            throw new RequestInvalidException();
+        }
+        return parsedLimit;
+    }
+
+}

--- a/src/main/java/real/world/domain/profile/query/Profile.java
+++ b/src/main/java/real/world/domain/profile/query/Profile.java
@@ -9,6 +9,8 @@ import real.world.domain.user.entity.User;
 @NoArgsConstructor
 public class Profile {
 
+    private Long id;
+
     private String username;
 
     private String bio;
@@ -17,7 +19,8 @@ public class Profile {
 
     private boolean following;
 
-    private Profile(String username, String bio, String image, boolean following) {
+    private Profile(Long id, String username, String bio, String image, boolean following) {
+        this.id = id;
         this.username = username;
         this.bio = bio;
         this.image = image;
@@ -26,11 +29,12 @@ public class Profile {
 
     @QueryProjection
     public Profile(User user, boolean following) {
-        this(user.getUsername(), user.getBio(), user.getImageUrl(), following);
+        this(user.getId(), user.getUsername(), user.getBio(), user.getImageUrl(), following);
     }
 
     public static Profile of(User user, boolean following) {
-        return new Profile(user.getUsername(), user.getBio(), user.getImageUrl(), following);
+        return new Profile(user.getId(), user.getUsername(), user.getBio(), user.getImageUrl(),
+            following);
     }
 
 }

--- a/src/main/java/real/world/domain/profile/query/ProfileQueryRepository.java
+++ b/src/main/java/real/world/domain/profile/query/ProfileQueryRepository.java
@@ -1,9 +1,15 @@
 package real.world.domain.profile.query;
 
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public interface ProfileQueryRepository {
 
     Optional<Profile> findByLoginIdAndUsername(Long loginId, String username);
+
+    Optional<Profile> findByLoginIdAndUserId(Long loginId, Long userId);
+
+    Map<Long, Profile> findByLoginIdAndIds(Long loginId, Set<Long> ids);
 
 }

--- a/src/main/java/real/world/domain/profile/query/ProfileQueryRepositoryImpl.java
+++ b/src/main/java/real/world/domain/profile/query/ProfileQueryRepositoryImpl.java
@@ -3,9 +3,14 @@ package real.world.domain.profile.query;
 import static real.world.domain.follow.entity.QFollow.follow;
 import static real.world.domain.user.entity.QUser.user;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -26,11 +31,43 @@ public class ProfileQueryRepositoryImpl implements ProfileQueryRepository {
                         user,
                         JPAExpressions.
                             selectFrom(follow)
-                            .where(follow.follower.id.eq(loginId).and(follow.user.username.eq(username)))
+                            .where(follow.follower.id.eq(loginId)
+                                .and(follow.user.username.eq(username)))
                             .exists()))
                 .from(user).
                 where(user.username.eq(username)).
                 fetchOne());
+    }
+
+    @Override
+    public Optional<Profile> findByLoginIdAndUserId(Long loginId, Long userId) {
+        return Optional.ofNullable(
+            factory
+                .select(
+                    new QProfile(
+                        user,
+                        JPAExpressions.
+                            selectFrom(follow)
+                            .where(follow.follower.id.eq(loginId)
+                                .and(follow.user.id.eq(userId)))
+                            .exists()))
+                .from(user).
+                where(user.id.eq(userId)).
+                fetchOne());
+    }
+
+    @Override
+    public Map<Long, Profile> findByLoginIdAndIds(Long loginId, Set<Long> ids) {
+        return factory.select(Projections.constructor(Profile.class,
+                user,
+                JPAExpressions.
+                    selectFrom(follow)
+                    .where(follow.follower.id.eq(loginId).and(follow.user.id.eq(user.id)))
+                    .exists())
+            )
+            .from(user)
+            .where(user.id.in(ids))
+            .fetch().stream().collect(Collectors.toMap(Profile::getId, Function.identity()));
     }
 
 }

--- a/src/main/java/real/world/error/exception/RequestInvalidException.java
+++ b/src/main/java/real/world/error/exception/RequestInvalidException.java
@@ -1,0 +1,11 @@
+package real.world.error.exception;
+
+import real.world.error.ErrorCode;
+
+public class RequestInvalidException extends BusinessException {
+
+    public RequestInvalidException() {
+        super(ErrorCode.REQUEST_INVALID);
+    }
+
+}

--- a/src/main/resources/application-data-local.yml
+++ b/src/main/resources/application-data-local.yml
@@ -14,4 +14,4 @@ spring:
         default_batch_fetch_size: 1000
         dialect: org.hibernate.dialect.MySQLDialect
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update

--- a/src/main/resources/application-web-local.yml
+++ b/src/main/resources/application-web-local.yml
@@ -1,6 +1,6 @@
 logging:
   level:
-    root: debug
+    root: info
 
 server:
   port: 8080

--- a/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
+++ b/src/test/java/real/world/domain/article/controller/ArticleControllerTest.java
@@ -68,7 +68,7 @@ public class ArticleControllerTest {
         @WithMockUserId(user = JOHN)
         void 상태코드200_으로_성공() throws Exception {
             // given
-            final ArticleView article = 게시물.뷰_생성(JOHN.getId());
+            final ArticleView article = 게시물.뷰_생성(JOHN.생성());
             final UploadRequest request = 게시물.업로드를_한다();
             final long 게시물_ID = 1L;
 
@@ -96,7 +96,7 @@ public class ArticleControllerTest {
         @WithMockUserId(user = JOHN)
         void 상태코드200_으로_성공() throws Exception {
             // given
-            final ArticleView article = 게시물.뷰_생성(JOHN.getId());
+            final ArticleView article = 게시물.뷰_생성(JOHN.생성());
             final String slug = article.getSlug();
             final long 게시물_ID = 1L;
 
@@ -140,7 +140,7 @@ public class ArticleControllerTest {
         @WithMockUserId(user = JOHN)
         void 상태코드200_으로_성공() throws Exception {
             // given
-            final ArticleView article = 게시물.뷰_생성(JOHN.getId());
+            final ArticleView article = 게시물.뷰_생성(JOHN.생성());
             final ArticleUpdateRequest request = 게시물.수정을_한다();
             final String slug = article.getSlug();
             final long 게시물_ID = 1L;
@@ -164,7 +164,7 @@ public class ArticleControllerTest {
         @WithMockUserId(user = JOHN)
         void 슬럭에_해당하는_아티클이_없다면_상태코드422로_실패() throws Exception {
             // given
-            final ArticleView article = 게시물.뷰_생성(JOHN.getId());
+            final ArticleView article = 게시물.뷰_생성(JOHN.생성());
             final ArticleUpdateRequest request = 게시물.수정을_한다();
             final String slug = article.getSlug();
 
@@ -191,7 +191,7 @@ public class ArticleControllerTest {
         @WithMockUserId(user = JOHN)
         void 상태코드200_으로_성공() throws Exception {
             // given
-            final ArticleView article = 게시물.뷰_생성(JOHN.getId());
+            final ArticleView article = 게시물.뷰_생성(JOHN.생성());
             final String slug = article.getSlug();
 
             // when
@@ -208,7 +208,7 @@ public class ArticleControllerTest {
         @WithMockUserId(user = JOHN)
         void 슬럭에_해당하는_아티클이_없다면_상태코드422로_실패() throws Exception {
             // given
-            final ArticleView article = 게시물.뷰_생성(JOHN.getId());
+            final ArticleView article = 게시물.뷰_생성(JOHN.생성());
             final String slug = article.getSlug();
 
             willThrow(new ArticleNotFoundException()).given(articleService)

--- a/src/test/java/real/world/fixture/ArticleFixtures.java
+++ b/src/test/java/real/world/fixture/ArticleFixtures.java
@@ -10,6 +10,8 @@ import real.world.domain.article.dto.request.UploadRequest;
 import real.world.domain.article.entity.Article;
 import real.world.domain.article.query.ArticleView;
 import real.world.domain.article.service.SlugTranslator;
+import real.world.domain.profile.query.Profile;
+import real.world.domain.user.entity.User;
 import real.world.support.StubSlugTranslator;
 
 @Getter
@@ -61,12 +63,14 @@ public enum ArticleFixtures {
         );
     }
 
-    public ArticleView 뷰_생성(Long userId) {
-        return new ArticleView(
-            생성(userId),
+    public ArticleView 뷰_생성(User user) {
+        final ArticleView articleView = new ArticleView(
+            생성(user.getId()),
             false,
             0
         );
+        articleView.setProfile(Profile.of(user, false));
+        return articleView;
     }
 
     public UploadRequest 업로드를_한다() {


### PR DESCRIPTION
##  📣요약
- 아티클 피드 조회 구현
- 아티클 응답에 프로필 추가
## ✨ 세부 내용
### 아티클 피드 조회 구현
- 팔로우 피드 구현
- 글로벌 검색 피드 구현
  - Querydsl의 동적 쿼리는 `BooleanExpression`을 통해 구현할 수 있음
  - `where`절에 `null`이 주어진다면, 해당 조건을 무시하고 넘어감. (다중 조건 검색 시 입력이 없는 조건을 무시할 수 있음)
### 아티클 응답에 프로필 추가
- 이전의 TODO 사항을 구현함. 이제 아티클 응답 시, 저자 정보가 포함되어 반환됨
- 구현하기 위해 `ProfileQueryRepository`에 두가지 메서드를 추가하였음
- `Profile` 필드에 `id`를 추가함
### 기타 수정 사항
- 어느정도 프로젝트가 진행되었으므로 `ddl-auto` 옵션을 `update`로 변경하였음. 완성 시 `verify`로 변경할 예정
- 로그 레벨을 `INFO`로 변경하였음. 디버그 로그가 필요한 경우 실행 시 `--debug` 옵션을 붙이면 됨

## TODO
- 시큐리티 설정 Optional 추가
- `order by` 적용
- 새 로직에 대한 테스트 작성
- @hyukji `ProifleQueryRepository` 테스트 작성 시 추가된 메서드도 작성해주면 될듯..