### PR TITLE
[Test] Profile test 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation:3.1.2'
 	implementation 'org.springframework.boot:spring-boot-starter-web:3.1.2'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator:3.1.2'
+	implementation 'org.hibernate.orm:hibernate-core:6.3.1.Final'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/real/world/domain/follow/entity/Follow.java
+++ b/src/main/java/real/world/domain/follow/entity/Follow.java
@@ -1,14 +1,12 @@
 package real.world.domain.follow.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.io.Serializable;
 import lombok.Getter;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import real.world.domain.user.entity.User;
 
 @Getter

--- a/src/main/java/real/world/domain/follow/entity/Follow.java
+++ b/src/main/java/real/world/domain/follow/entity/Follow.java
@@ -1,12 +1,14 @@
 package real.world.domain.follow.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.io.Serializable;
 import lombok.Getter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import real.world.domain.user.entity.User;
 
 @Getter

--- a/src/main/java/real/world/domain/follow/service/FollowService.java
+++ b/src/main/java/real/world/domain/follow/service/FollowService.java
@@ -1,5 +1,6 @@
 package real.world.domain.follow.service;
 
+import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 import real.world.domain.follow.entity.Follow;
 import real.world.domain.follow.repository.FollowRepository;
@@ -24,6 +25,7 @@ public class FollowService {
         this.followRepository = followRepository;
     }
 
+    @Transactional
     public ProfileResponse follow(Long loginId, String username) {
         final User user = userRepository.findByUsername(username)
             .orElseThrow(UsernameNotExistException::new);
@@ -40,6 +42,7 @@ public class FollowService {
         return ProfileResponse.of(user, true);
     }
 
+    @Transactional
     public ProfileResponse unfollow(Long loginId, String username) {
         final User user = userRepository.findByUsername(username)
             .orElseThrow(UsernameNotExistException::new);

--- a/src/main/java/real/world/domain/user/service/UserService.java
+++ b/src/main/java/real/world/domain/user/service/UserService.java
@@ -1,9 +1,9 @@
 package real.world.domain.user.service;
 
+import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import real.world.domain.user.dto.request.RegisterRequest;
 import real.world.domain.user.dto.request.UpdateRequest;
 import real.world.domain.user.dto.response.UserResponse;

--- a/src/test/java/real/world/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/real/world/domain/follow/service/FollowServiceTest.java
@@ -1,7 +1,6 @@
 package real.world.domain.follow.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -38,13 +37,13 @@ class FollowServiceTest {
         void 정상_호출시_팔로우를_하고_응답을_반환한다() {
             // given
             final User user = JOHN.생성();
-            final User LoginUser = ALICE.생성();
+            final User loginUser = ALICE.생성();
             given(userRepository.findByUsername(user.getUsername())).willReturn(Optional.of(user));
-            given(userRepository.findById(LoginUser.getId())).willReturn(Optional.of(LoginUser));
-            given(followRepository.existsByUserIdAndFollowerId(user.getId(), LoginUser.getId())).willReturn(false);
+            given(userRepository.findById(loginUser.getId())).willReturn(Optional.of(loginUser));
+            given(followRepository.existsByUserIdAndFollowerId(user.getId(), loginUser.getId())).willReturn(false);
 
             // when
-            final ProfileResponse response = followService.follow(LoginUser.getId(), user.getUsername());
+            final ProfileResponse response = followService.follow(loginUser.getId(), user.getUsername());
 
             // then
             assertAll(() -> {
@@ -60,14 +59,14 @@ class FollowServiceTest {
         void 팔로우가_이미_되어있을_때_예외를_던진다() {
             // given
             final User user = JOHN.생성();
-            final User LoginUser = ALICE.생성();
+            final User loginUser = ALICE.생성();
             given(userRepository.findByUsername(user.getUsername())).willReturn(Optional.of(user));
-            given(userRepository.findById(LoginUser.getId())).willReturn(Optional.of(LoginUser));
-            given(followRepository.existsByUserIdAndFollowerId(user.getId(), LoginUser.getId())).willReturn(true);
+            given(userRepository.findById(loginUser.getId())).willReturn(Optional.of(loginUser));
+            given(followRepository.existsByUserIdAndFollowerId(user.getId(), loginUser.getId())).willReturn(true);
 
             // when & then
             assertThatThrownBy(() ->
-                followService.follow(LoginUser.getId(), user.getUsername())
+                followService.follow(loginUser.getId(), user.getUsername())
             ).isInstanceOf(AlreadyFollowingException.class);
         }
 
@@ -75,12 +74,12 @@ class FollowServiceTest {
         void 유저가_존재하지_않을_시_에외를_던진다() {
             // given
             final User user = JOHN.생성();
-            final User LoginUser = ALICE.생성();
+            final User loginUser = ALICE.생성();
             given(userRepository.findByUsername(user.getUsername())).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(
-                () -> followService.follow(LoginUser.getId(), user.getUsername())
+                () -> followService.follow(loginUser.getId(), user.getUsername())
             ).isInstanceOf(UsernameNotExistException.class);
         }
 
@@ -93,13 +92,13 @@ class FollowServiceTest {
         void 정상_호출시_팔로우를_취소하고_응답을_반환한다() {
             // given
             final User user = JOHN.생성();
-            final User LoginUser = ALICE.생성();
+            final User loginUser = ALICE.생성();
             given(userRepository.findByUsername(user.getUsername())).willReturn(Optional.of(user));
-            given(userRepository.findById(LoginUser.getId())).willReturn(Optional.of(LoginUser));
-            given(followRepository.existsByUserIdAndFollowerId(user.getId(), LoginUser.getId())).willReturn(true);
+            given(userRepository.findById(loginUser.getId())).willReturn(Optional.of(loginUser));
+            given(followRepository.existsByUserIdAndFollowerId(user.getId(), loginUser.getId())).willReturn(true);
 
             // when
-            final ProfileResponse response = followService.unfollow(LoginUser.getId(), user.getUsername());
+            final ProfileResponse response = followService.unfollow(loginUser.getId(), user.getUsername());
 
             // then
             assertAll(() -> {
@@ -112,17 +111,17 @@ class FollowServiceTest {
         }
 
         @Test
-        void 팔로우가_존재하지_않을_시_예외를_반환한다() {
+        void 팔로우가_존재하지_않을_시_예외를_던진다() {
             // given
             final User user = JOHN.생성();
-            final User follower = ALICE.생성();
+            final User loginUser = ALICE.생성();
             given(userRepository.findByUsername(user.getUsername())).willReturn(Optional.of(user));
-            given(userRepository.findById(follower.getId())).willReturn(Optional.of(follower));
-            given(followRepository.existsByUserIdAndFollowerId(user.getId(), follower.getId())).willReturn(false);
+            given(userRepository.findById(loginUser.getId())).willReturn(Optional.of(loginUser));
+            given(followRepository.existsByUserIdAndFollowerId(user.getId(), loginUser.getId())).willReturn(false);
 
             // when & then
             assertThatThrownBy(
-                () -> followService.unfollow(follower.getId(), user.getUsername())
+                () -> followService.unfollow(loginUser.getId(), user.getUsername())
             ).isInstanceOf(FollowNotExistException.class);
         }
     }

--- a/src/test/java/real/world/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/real/world/domain/follow/service/FollowServiceTest.java
@@ -1,6 +1,7 @@
 package real.world.domain.follow.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -18,6 +19,8 @@ import real.world.domain.follow.entity.Follow;
 import real.world.domain.follow.repository.FollowRepository;
 import real.world.domain.user.entity.User;
 import real.world.domain.user.repository.UserRepository;
+import real.world.error.exception.AlreadyFollowingException;
+import real.world.error.exception.FollowNotExistException;
 import real.world.error.exception.UsernameNotExistException;
 
 class FollowServiceTest {
@@ -35,13 +38,13 @@ class FollowServiceTest {
         void 정상_호출시_팔로우를_하고_응답을_반환한다() {
             // given
             final User user = JOHN.생성();
-            final User follower = ALICE.생성();
+            final User LoginUser = ALICE.생성();
             given(userRepository.findByUsername(user.getUsername())).willReturn(Optional.of(user));
-            given(userRepository.findById(follower.getId())).willReturn(Optional.of(follower));
-            given(followRepository.existsByUserIdAndFollowerId(user.getId(), follower.getId())).willReturn(false);
+            given(userRepository.findById(LoginUser.getId())).willReturn(Optional.of(LoginUser));
+            given(followRepository.existsByUserIdAndFollowerId(user.getId(), LoginUser.getId())).willReturn(false);
 
             // when
-            final ProfileResponse response = followService.follow(follower.getId(), user.getUsername());
+            final ProfileResponse response = followService.follow(LoginUser.getId(), user.getUsername());
 
             // then
             assertAll(() -> {
@@ -54,15 +57,30 @@ class FollowServiceTest {
         }
 
         @Test
+        void 팔로우가_이미_되어있을_때_예외를_던진다() {
+            // given
+            final User user = JOHN.생성();
+            final User LoginUser = ALICE.생성();
+            given(userRepository.findByUsername(user.getUsername())).willReturn(Optional.of(user));
+            given(userRepository.findById(LoginUser.getId())).willReturn(Optional.of(LoginUser));
+            given(followRepository.existsByUserIdAndFollowerId(user.getId(), LoginUser.getId())).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() ->
+                followService.follow(LoginUser.getId(), user.getUsername())
+            ).isInstanceOf(AlreadyFollowingException.class);
+        }
+
+        @Test
         void 유저가_존재하지_않을_시_에외를_던진다() {
             // given
             final User user = JOHN.생성();
-            final User follower = ALICE.생성();
+            final User LoginUser = ALICE.생성();
             given(userRepository.findByUsername(user.getUsername())).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(
-                () -> followService.follow(follower.getId(), user.getUsername())
+                () -> followService.follow(LoginUser.getId(), user.getUsername())
             ).isInstanceOf(UsernameNotExistException.class);
         }
 
@@ -75,13 +93,13 @@ class FollowServiceTest {
         void 정상_호출시_팔로우를_취소하고_응답을_반환한다() {
             // given
             final User user = JOHN.생성();
-            final User follower = ALICE.생성();
+            final User LoginUser = ALICE.생성();
             given(userRepository.findByUsername(user.getUsername())).willReturn(Optional.of(user));
-            given(userRepository.findById(follower.getId())).willReturn(Optional.of(follower));
-            given(followRepository.existsByUserIdAndFollowerId(user.getId(), follower.getId())).willReturn(true);
+            given(userRepository.findById(LoginUser.getId())).willReturn(Optional.of(LoginUser));
+            given(followRepository.existsByUserIdAndFollowerId(user.getId(), LoginUser.getId())).willReturn(true);
 
             // when
-            final ProfileResponse response = followService.unfollow(follower.getId(), user.getUsername());
+            final ProfileResponse response = followService.unfollow(LoginUser.getId(), user.getUsername());
 
             // then
             assertAll(() -> {
@@ -93,6 +111,20 @@ class FollowServiceTest {
             });
         }
 
+        @Test
+        void 팔로우가_존재하지_않을_시_예외를_반환한다() {
+            // given
+            final User user = JOHN.생성();
+            final User follower = ALICE.생성();
+            given(userRepository.findByUsername(user.getUsername())).willReturn(Optional.of(user));
+            given(userRepository.findById(follower.getId())).willReturn(Optional.of(follower));
+            given(followRepository.existsByUserIdAndFollowerId(user.getId(), follower.getId())).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(
+                () -> followService.unfollow(follower.getId(), user.getUsername())
+            ).isInstanceOf(FollowNotExistException.class);
+        }
     }
 
 }

--- a/src/test/java/real/world/domain/profile/query/ProfileQueryRepositoryTest.java
+++ b/src/test/java/real/world/domain/profile/query/ProfileQueryRepositoryTest.java
@@ -1,0 +1,67 @@
+package real.world.domain.profile.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static real.world.fixture.UserFixtures.ALICE;
+import static real.world.fixture.UserFixtures.JOHN;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import real.world.e2e.util.DBInitializer;
+import real.world.support.QueryRepositoryTest;
+
+@Import(ProfileQueryRepositoryImpl.class)
+class ProfileQueryRepositoryTest extends QueryRepositoryTest {
+
+    @Autowired
+    private ProfileQueryRepository profileQueryRepository;
+
+    @Autowired
+    private DBInitializer dbInitializer;
+
+    @Test
+    void 팔로우중인_유저의_프로필_가져오기() {
+        // given
+        dbInitializer.JOHN이_ALICE를_팔로우한다();
+        Long loginId = JOHN.getId();
+        String username = ALICE.getUsername();
+
+        // when
+        Optional<Profile> result = profileQueryRepository.findByLoginIdAndUsername(loginId, username);
+
+        // then
+        assertAll(() -> {
+            assertThat(result.isPresent()).isTrue();
+            final Profile profile = result.get();
+            assertThat(profile.getUsername()).isEqualTo(ALICE.getUsername());
+            assertThat(profile.getBio()).isEqualTo(ALICE.getBio());
+            assertThat(profile.getImage()).isEqualTo(ALICE.getImageUrl());
+            assertThat(profile.isFollowing()).isEqualTo(true);
+        });
+    }
+
+    @Test
+    void 팔로우중이_아닌_유저의_프로필_가져오기() {
+        // given
+        dbInitializer.유저들이_회원가입_돼있다();
+        Long loginId = JOHN.getId();
+        String username = ALICE.getUsername();
+
+        // when
+        Optional<Profile> result = profileQueryRepository.findByLoginIdAndUsername(loginId, username);
+
+        // then
+        assertAll(() -> {
+            assertThat(result.isPresent()).isTrue();
+            final Profile profile = result.get();
+            assertThat(profile.getUsername()).isEqualTo(ALICE.getUsername());
+            assertThat(profile.getBio()).isEqualTo(ALICE.getBio());
+            assertThat(profile.getImage()).isEqualTo(ALICE.getImageUrl());
+            assertThat(profile.isFollowing()).isEqualTo(false);
+        });
+
+    }
+
+}

--- a/src/test/java/real/world/domain/profile/service/ProfileQueryServiceTest.java
+++ b/src/test/java/real/world/domain/profile/service/ProfileQueryServiceTest.java
@@ -32,13 +32,13 @@ class ProfileQueryServiceTest {
         void 로그인이_되어있고_정상_호출시_프로필을_반환한다() {
             // given
             final User user = JOHN.생성();
-            final Long followerId = ALICE.생성().getId();
+            final Long loginId = ALICE.생성().getId();
             final Profile profile = Profile.of(user, true);
-            given(profileQueryRepository.findByLoginIdAndUsername(eq(followerId), eq(user.getUsername()))).willReturn(
+            given(profileQueryRepository.findByLoginIdAndUsername(eq(loginId), eq(user.getUsername()))).willReturn(
                 Optional.of(profile));
 
             // when
-            final ProfileResponse response = profileQueryService.getProfile(followerId, user.getUsername());
+            final ProfileResponse response = profileQueryService.getProfile(loginId, user.getUsername());
 
             // then
             assertAll(() -> {

--- a/src/test/java/real/world/domain/profile/service/ProfileQueryServiceTest.java
+++ b/src/test/java/real/world/domain/profile/service/ProfileQueryServiceTest.java
@@ -32,7 +32,7 @@ class ProfileQueryServiceTest {
         void 로그인이_되어있고_정상_호출시_프로필을_반환한다() {
             // given
             final User user = JOHN.생성();
-            final Long loginId = ALICE.생성().getId();
+            final Long loginId = ALICE.getId();
             final Profile profile = Profile.of(user, true);
             given(profileQueryRepository.findByLoginIdAndUsername(eq(loginId), eq(user.getUsername()))).willReturn(
                 Optional.of(profile));

--- a/src/test/java/real/world/e2e/E2ETest.java
+++ b/src/test/java/real/world/e2e/E2ETest.java
@@ -27,7 +27,6 @@ abstract class E2ETest {
         RestAssured.port = port;
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.enable(SerializationFeature.WRAP_ROOT_VALUE);
-        objectMapper.enable(DeserializationFeature.UNWRAP_ROOT_VALUE);
         objectMapper.registerModule(new JavaTimeModule());
         RestAssured.config = RestAssured.config()
             .objectMapperConfig(new ObjectMapperConfig().jackson2ObjectMapperFactory(

--- a/src/test/java/real/world/e2e/ProfileE2ETest.java
+++ b/src/test/java/real/world/e2e/ProfileE2ETest.java
@@ -1,0 +1,105 @@
+package real.world.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static real.world.e2e.RestAssuredUtils.로그인_상태로_GET_요청을_보낸다;
+import static real.world.e2e.RestAssuredUtils.로그인_상태로_POST_요청을_보낸다;
+import static real.world.fixture.UserFixtures.ALICE;
+import static real.world.fixture.UserFixtures.JOHN;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import real.world.domain.profile.dto.response.ProfileResponse;
+import real.world.e2e.util.DBInitializer;
+
+public class ProfileE2ETest extends E2ETest {
+
+    @Autowired
+    private DBInitializer dbInitializer;
+
+    @Test
+    void 팔로우중인_유저의_프로필을_가져온다() {
+        // given
+        dbInitializer.JOHN이_ALICE를_팔로우한다();
+
+        // when
+        final ExtractableResponse<Response> extractableResponse = 로그인_상태로_GET_요청을_보낸다(
+            JOHN, "/profiles/" + ALICE.getUsername());
+        final ProfileResponse response = extractableResponse.as(ProfileResponse.class);
+
+        // then
+        assertAll(() -> {
+            assertThat(extractableResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertThat(response.getUsername()).isEqualTo(ALICE.getUsername());
+            assertThat(response.getBio()).isEqualTo(ALICE.getBio());
+            assertThat(response.getImage()).isEqualTo(ALICE.getImageUrl());
+            assertThat(response.isFollowing()).isEqualTo(true);
+        });
+    }
+
+    @Test
+    void 팔로우중이_아닌_유저의_프로필을_가져온다() {
+        // given
+        dbInitializer.유저들이_회원가입_돼있다();
+
+        // when
+        final ExtractableResponse<Response> extractableResponse = 로그인_상태로_GET_요청을_보낸다(
+            JOHN, "/profiles/" + ALICE.getUsername());
+        final ProfileResponse response = extractableResponse.as(ProfileResponse.class);
+
+        // then
+        assertAll(() -> {
+            assertThat(extractableResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertThat(response.getUsername()).isEqualTo(ALICE.getUsername());
+            assertThat(response.getBio()).isEqualTo(ALICE.getBio());
+            assertThat(response.getImage()).isEqualTo(ALICE.getImageUrl());
+            assertThat(response.isFollowing()).isEqualTo(false);
+        });
+    }
+
+    @Test
+    void 팔로우를_한다() {
+        // given
+        dbInitializer.JOHN이_ALICE를_팔로우한다();
+
+        // when
+        final ExtractableResponse<Response> extractableResponse = 로그인_상태로_POST_요청을_보낸다(
+            JOHN, "/profiles/" + ALICE.getUsername() + "/follow", "");
+        final ProfileResponse response = extractableResponse.as(ProfileResponse.class);
+
+        // then
+        assertAll(() -> {
+            assertThat(extractableResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertThat(response.getUsername()).isEqualTo(ALICE.getUsername());
+            assertThat(response.getBio()).isEqualTo(ALICE.getBio());
+            assertThat(response.getImage()).isEqualTo(ALICE.getImageUrl());
+            assertThat(response.isFollowing()).isEqualTo(true);
+        });
+
+    }
+
+    @Test
+    void 팔로우를_취소한다() {
+        // given
+        dbInitializer.JOHN이_ALICE를_팔로우한다();
+
+        // when
+        final ExtractableResponse<Response> extractableResponse = 로그인_상태로_POST_요청을_보낸다(
+            JOHN, "/profiles/" + ALICE.getUsername() + "/unfollow", "");
+        final ProfileResponse response = extractableResponse.as(ProfileResponse.class);
+
+        // then
+        assertAll(() -> {
+            assertThat(extractableResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertThat(response.getUsername()).isEqualTo(ALICE.getUsername());
+            assertThat(response.getBio()).isEqualTo(ALICE.getBio());
+            assertThat(response.getImage()).isEqualTo(ALICE.getImageUrl());
+            assertThat(response.isFollowing()).isEqualTo(false);
+        });
+
+    }
+
+}

--- a/src/test/java/real/world/e2e/ProfileE2ETest.java
+++ b/src/test/java/real/world/e2e/ProfileE2ETest.java
@@ -63,7 +63,7 @@ public class ProfileE2ETest extends E2ETest {
     @Test
     void 팔로우를_한다() {
         // given
-        dbInitializer.JOHN이_ALICE를_팔로우한다();
+        dbInitializer.유저들이_회원가입_돼있다();
 
         // when
         final ExtractableResponse<Response> extractableResponse = 로그인_상태로_POST_요청을_보낸다(

--- a/src/test/java/real/world/e2e/ProfileE2ETest.java
+++ b/src/test/java/real/world/e2e/ProfileE2ETest.java
@@ -12,7 +12,7 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import real.world.domain.profile.dto.response.ProfileResponse;
+import real.world.domain.profile.dto.response.ProfileApiResponse;
 import real.world.e2e.util.DBInitializer;
 
 public class ProfileE2ETest extends E2ETest {
@@ -28,15 +28,15 @@ public class ProfileE2ETest extends E2ETest {
         // when
         final ExtractableResponse<Response> extractableResponse = 로그인_상태로_GET_요청을_보낸다(
             JOHN, "/profiles/" + ALICE.getUsername());
-        final ProfileResponse response = extractableResponse.as(ProfileResponse.class);
+        final ProfileApiResponse response = extractableResponse.as(ProfileApiResponse.class);
 
         // then
         assertAll(() -> {
             assertThat(extractableResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
-            assertThat(response.getUsername()).isEqualTo(ALICE.getUsername());
-            assertThat(response.getBio()).isEqualTo(ALICE.getBio());
-            assertThat(response.getImage()).isEqualTo(ALICE.getImageUrl());
-            assertThat(response.isFollowing()).isEqualTo(true);
+            assertThat(response.getProfile().getUsername()).isEqualTo(ALICE.getUsername());
+            assertThat(response.getProfile().getBio()).isEqualTo(ALICE.getBio());
+            assertThat(response.getProfile().getImage()).isEqualTo(ALICE.getImageUrl());
+            assertThat(response.getProfile().isFollowing()).isEqualTo(true);
         });
     }
 
@@ -48,15 +48,15 @@ public class ProfileE2ETest extends E2ETest {
         // when
         final ExtractableResponse<Response> extractableResponse = 로그인_상태로_GET_요청을_보낸다(
             JOHN, "/profiles/" + ALICE.getUsername());
-        final ProfileResponse response = extractableResponse.as(ProfileResponse.class);
+        final ProfileApiResponse response = extractableResponse.as(ProfileApiResponse.class);
 
         // then
         assertAll(() -> {
             assertThat(extractableResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
-            assertThat(response.getUsername()).isEqualTo(ALICE.getUsername());
-            assertThat(response.getBio()).isEqualTo(ALICE.getBio());
-            assertThat(response.getImage()).isEqualTo(ALICE.getImageUrl());
-            assertThat(response.isFollowing()).isEqualTo(false);
+            assertThat(response.getProfile().getUsername()).isEqualTo(ALICE.getUsername());
+            assertThat(response.getProfile().getBio()).isEqualTo(ALICE.getBio());
+            assertThat(response.getProfile().getImage()).isEqualTo(ALICE.getImageUrl());
+            assertThat(response.getProfile().isFollowing()).isEqualTo(false);
         });
     }
 
@@ -68,15 +68,15 @@ public class ProfileE2ETest extends E2ETest {
         // when
         final ExtractableResponse<Response> extractableResponse = 로그인_상태로_POST_요청을_보낸다(
             JOHN, "/profiles/" + ALICE.getUsername() + "/follow", "");
-        final ProfileResponse response = extractableResponse.as(ProfileResponse.class);
+        final ProfileApiResponse response = extractableResponse.as(ProfileApiResponse.class);
 
         // then
         assertAll(() -> {
             assertThat(extractableResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
-            assertThat(response.getUsername()).isEqualTo(ALICE.getUsername());
-            assertThat(response.getBio()).isEqualTo(ALICE.getBio());
-            assertThat(response.getImage()).isEqualTo(ALICE.getImageUrl());
-            assertThat(response.isFollowing()).isEqualTo(true);
+            assertThat(response.getProfile().getUsername()).isEqualTo(ALICE.getUsername());
+            assertThat(response.getProfile().getBio()).isEqualTo(ALICE.getBio());
+            assertThat(response.getProfile().getImage()).isEqualTo(ALICE.getImageUrl());
+            assertThat(response.getProfile().isFollowing()).isEqualTo(true);
         });
 
     }
@@ -89,15 +89,15 @@ public class ProfileE2ETest extends E2ETest {
         // when
         final ExtractableResponse<Response> extractableResponse = 로그인_상태로_POST_요청을_보낸다(
             JOHN, "/profiles/" + ALICE.getUsername() + "/unfollow", "");
-        final ProfileResponse response = extractableResponse.as(ProfileResponse.class);
+        final ProfileApiResponse response = extractableResponse.as(ProfileApiResponse.class);
 
         // then
         assertAll(() -> {
             assertThat(extractableResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
-            assertThat(response.getUsername()).isEqualTo(ALICE.getUsername());
-            assertThat(response.getBio()).isEqualTo(ALICE.getBio());
-            assertThat(response.getImage()).isEqualTo(ALICE.getImageUrl());
-            assertThat(response.isFollowing()).isEqualTo(false);
+            assertThat(response.getProfile().getUsername()).isEqualTo(ALICE.getUsername());
+            assertThat(response.getProfile().getBio()).isEqualTo(ALICE.getBio());
+            assertThat(response.getProfile().getImage()).isEqualTo(ALICE.getImageUrl());
+            assertThat(response.getProfile().isFollowing()).isEqualTo(false);
         });
 
     }

--- a/src/test/java/real/world/e2e/util/DBInitializer.java
+++ b/src/test/java/real/world/e2e/util/DBInitializer.java
@@ -9,6 +9,7 @@ import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import real.world.fixture.ArticleFixtures;
+import real.world.fixture.FollowFixtures;
 
 @Component
 public class DBInitializer {
@@ -19,8 +20,8 @@ public class DBInitializer {
     @Transactional
     public void 유저들이_회원가입_돼있다() {
         entityManager.persist(JOHN.지정된_ID로_생성(null));
-        entityManager.persist(BOB.지정된_ID로_생성(null));
         entityManager.persist(ALICE.지정된_ID로_생성(null));
+        entityManager.persist(BOB.지정된_ID로_생성(null));
     }
 
     @Transactional
@@ -35,6 +36,12 @@ public class DBInitializer {
         entityManager.persist(ArticleFixtures.게시물.생성(JOHN.getId()));
         entityManager.persist(ArticleFixtures.게시물_2.생성(JOHN.getId()));
         entityManager.persist(ArticleFixtures.게시물_3.생성(JOHN.getId()));
+    }
+
+    @Transactional
+    public void JOHN이_ALICE를_팔로우한다() {
+        유저들이_회원가입_돼있다();
+        entityManager.persist(FollowFixtures.JOHN이_ALICE를_팔로우.생성());
     }
 
 }

--- a/src/test/java/real/world/fixture/FollowFixtures.java
+++ b/src/test/java/real/world/fixture/FollowFixtures.java
@@ -1,0 +1,30 @@
+package real.world.fixture;
+
+import static real.world.fixture.UserFixtures.ALICE;
+import static real.world.fixture.UserFixtures.JOHN;
+
+import lombok.Getter;
+import real.world.domain.follow.entity.Follow;
+
+@Getter
+public enum FollowFixtures {
+
+    JOHN이_ALICE를_팔로우(JOHN, ALICE);
+
+    private final UserFixtures follower;
+
+    private final UserFixtures user;
+
+    FollowFixtures(UserFixtures follower, UserFixtures user) {
+        this.follower = follower;
+        this.user = user;
+    }
+
+    public Follow 생성() {
+        return new Follow(
+            user.생성(),
+            follower.생성()
+        );
+    }
+
+}

--- a/src/test/java/real/world/support/QueryRepositoryTest.java
+++ b/src/test/java/real/world/support/QueryRepositoryTest.java
@@ -1,0 +1,25 @@
+package real.world.support;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import real.world.config.JpaConfig;
+import real.world.e2e.util.DBInitializer;
+import real.world.e2e.util.DatabaseCleaner;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaConfig.class, DBInitializer.class, DatabaseCleaner.class})
+public abstract class QueryRepositoryTest {
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void clean() {
+        databaseCleaner.clean();
+    }
+
+}

--- a/src/test/java/real/world/support/TestSecurityConfig.java
+++ b/src/test/java/real/world/support/TestSecurityConfig.java
@@ -21,7 +21,7 @@ public class TestSecurityConfig {
 
     private static final String[] AUTH_PATH = {"/users", LOGIN_PATH};
 
-    private static final String[]  OPTIONAL_PATH = {"/profiles/*"};
+    private static final String[] OPTIONAL_PATH = {"/profiles/*"};
 
     private static final String[] SWAGGER_PATH = {"/docs/open-api.json", "/swagger-ui/**",
         "/v3/**"};
@@ -35,7 +35,7 @@ public class TestSecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.POST, AUTH_PATH).permitAll()
                 .requestMatchers(HttpMethod.GET, SWAGGER_PATH).permitAll()
-                .requestMatchers(HttpMethod.GET, OPTIONAL_PATH).permitAll()
+                .requestMatchers(OPTIONAL_PATH).hasAnyRole("USER", "ANONYMOUS")
                 .anyRequest().hasRole("USER")
             )
             .sessionManagement(

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,8 +5,6 @@ spring:
   jackson:
     deserialization:
       unwrap-root-value: true
-    serialization:
-      wrap-root-value: true
 
   datasource:
     url: jdbc:h2:mem:test_real;MODE=MYSQL;


### PR DESCRIPTION
##  📣요약
- profile api 관련 테스트 작성

## ✨ 세부 내용
- 단위 테스트 및 통합테스트 수정
- ProfileE2E 테스트 작성

### abstract class `QueryServiceTest` 작성 
- @DataJpaTest와 , AutoConfigureTestDatabase.Replace.NONE 등 queryService test에 필요한 어노테이션 추가.
- db 초기화 과정 추가

### 의존성 수정 
현재 사용중인  `org.springframework.boot:spring-boot-starter-data-jpa:3.1.2`에 포함된 `org.hibernate.orm:hibernate-core:6.2.6` 과 관련된 문제로 해당버전을 버전을 `6.3.1`로 수정함
참고자료 : `https://hibernate.atlassian.net/browse/HHH-16988` 

