### PR TITLE
[Test] ProifleQueryRepository 테스트 작성

### DIFF
--- a/http/profile.http
+++ b/http/profile.http
@@ -1,0 +1,55 @@
+### 회원가입
+POST {{domain}}/api/users
+Content-Type: application/json
+
+{
+  "user": {
+    "username": {{username}},
+    "email": {{email}},
+    "password": "1234"
+  }
+}
+
+### 로그인
+POST {{domain}}/api/users/login
+Content-Type: application/json
+
+{
+  "user": {
+    "email": {{email}},
+    "password": "1234"
+  }
+}
+
+> {%
+  const token = response.headers.valueOf("Authorization");
+
+  client.test("Validate", function() {
+    client.assert(response.status === 200, "Response status invalid");
+    client.assert(response.contentType.mimeType === "application/json", "Content-type invalid");
+    client.assert(response.headers.valueOf("Authorization").startsWith("Token") === true, "Authorization invalid");
+  });
+
+  client.log(token);
+  client.global.set("access_token", token);
+%}
+
+### 팔로우 전 프로필 조회
+GET {{domain}}/api/profiles/{{target}}
+Authorization: {{access_token}}
+
+### 팔로우
+POST {{domain}}/api/profiles/{{target}}/follow
+Authorization: {{access_token}}
+
+### 팔로우 후 프로필 조회
+GET {{domain}}/api/profiles/{{target}}
+Authorization: {{access_token}}
+
+### 팔로우 취소
+POST {{domain}}/api/profiles/{{target}}/unfollow
+Authorization: {{access_token}}
+
+### 팔로우 취소 후 프로필 조회
+GET {{domain}}/api/profiles/{{target}}
+Authorization: {{access_token}}

--- a/src/main/java/real/world/domain/profile/query/Profile.java
+++ b/src/main/java/real/world/domain/profile/query/Profile.java
@@ -1,6 +1,5 @@
 package real.world.domain.profile.query;
 
-import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import real.world.domain.user.entity.User;
@@ -27,7 +26,6 @@ public class Profile {
         this.following = following;
     }
 
-    @QueryProjection
     public Profile(User user, boolean following) {
         this(user.getId(), user.getUsername(), user.getBio(), user.getImageUrl(), following);
     }

--- a/src/main/java/real/world/domain/profile/query/ProfileQueryRepositoryImpl.java
+++ b/src/main/java/real/world/domain/profile/query/ProfileQueryRepositoryImpl.java
@@ -26,8 +26,7 @@ public class ProfileQueryRepositoryImpl implements ProfileQueryRepository {
     public Optional<Profile> findByLoginIdAndUsername(Long loginId, String username) {
         return Optional.ofNullable(
             factory
-                .select(
-                    new QProfile(
+                .select(Projections.constructor(Profile.class,
                         user,
                         JPAExpressions.
                             selectFrom(follow)
@@ -43,8 +42,7 @@ public class ProfileQueryRepositoryImpl implements ProfileQueryRepository {
     public Optional<Profile> findByLoginIdAndUserId(Long loginId, Long userId) {
         return Optional.ofNullable(
             factory
-                .select(
-                    new QProfile(
+                .select(Projections.constructor(Profile.class,
                         user,
                         JPAExpressions.
                             selectFrom(follow)

--- a/src/test/java/real/world/domain/profile/query/ProfileQueryRepositoryTest.java
+++ b/src/test/java/real/world/domain/profile/query/ProfileQueryRepositoryTest.java
@@ -8,6 +8,7 @@ import static real.world.fixture.UserFixtures.JOHN;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -29,7 +30,7 @@ class ProfileQueryRepositoryTest extends QueryRepositoryTest {
     private DBInitializer dbInitializer;
 
     @Test
-    void 유저네임을_이용해_팔로우중인_유저의_프로필_가져오기() {
+    void 유저네임을_이용해_팔로우중인_유저의_프로필_가져온다() {
         // given
         dbInitializer.JOHN이_ALICE를_팔로우한다();
 
@@ -47,7 +48,7 @@ class ProfileQueryRepositoryTest extends QueryRepositoryTest {
     }
 
     @Test
-    void 유저네임을_이용해_팔로우중이_아닌_유저의_프로필_가져오기() {
+    void 유저네임을_이용해_팔로우중이_아닌_유저의_프로필_가져온다() {
         // given
         dbInitializer.유저들이_회원가입_돼있다();
 
@@ -66,7 +67,7 @@ class ProfileQueryRepositoryTest extends QueryRepositoryTest {
     }
 
     @Test
-    void 유저id를_이용해_팔로우중인_유저의_프로필_가져오기() {
+    void 유저id를_이용해_팔로우중인_유저의_프로필_가져온다() {
         // given
         dbInitializer.JOHN이_ALICE를_팔로우한다();
 
@@ -84,7 +85,7 @@ class ProfileQueryRepositoryTest extends QueryRepositoryTest {
     }
 
     @Test
-    void 유저id를_이용해_팔로우중이_아닌_유저의_프로필_가져오기() {
+    void 유저id를_이용해_팔로우중이_아닌_유저의_프로필_가져온다() {
         // given
         dbInitializer.유저들이_회원가입_돼있다();
 
@@ -103,12 +104,12 @@ class ProfileQueryRepositoryTest extends QueryRepositoryTest {
     }
 
     @Test
-    void 타겟_유저들의_프로필_가져오기() {
+    void 타겟_유저들의_프로필_가져온다() {
         // given
         dbInitializer.JOHN이_ALICE와_BOB을_팔로우한다();
 
         Long loginId = JOHN.getId();
-        ArrayList<UserFixtures> userFixtures = new ArrayList<>(Arrays.asList(ALICE, BOB));
+        List<UserFixtures> userFixtures = List.of(ALICE, BOB);
         Set<Long> ids = userFixtures.stream().map(UserFixtures::getId)
             .collect(Collectors.toSet());
 

--- a/src/test/java/real/world/domain/profile/query/ProfileQueryRepositoryTest.java
+++ b/src/test/java/real/world/domain/profile/query/ProfileQueryRepositoryTest.java
@@ -3,13 +3,20 @@ package real.world.domain.profile.query;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static real.world.fixture.UserFixtures.ALICE;
+import static real.world.fixture.UserFixtures.BOB;
 import static real.world.fixture.UserFixtures.JOHN;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import real.world.e2e.util.DBInitializer;
+import real.world.fixture.UserFixtures;
 import real.world.support.QueryRepositoryTest;
 
 @Import(ProfileQueryRepositoryImpl.class)
@@ -22,46 +29,107 @@ class ProfileQueryRepositoryTest extends QueryRepositoryTest {
     private DBInitializer dbInitializer;
 
     @Test
-    void 팔로우중인_유저의_프로필_가져오기() {
+    void 유저네임을_이용해_팔로우중인_유저의_프로필_가져오기() {
         // given
         dbInitializer.JOHN이_ALICE를_팔로우한다();
+
         Long loginId = JOHN.getId();
-        String username = ALICE.getUsername();
+        UserFixtures userFixture = ALICE;
 
         // when
-        Optional<Profile> result = profileQueryRepository.findByLoginIdAndUsername(loginId, username);
+        Optional<Profile> result = profileQueryRepository.findByLoginIdAndUsername(loginId, userFixture.getUsername());
 
         // then
         assertAll(() -> {
             assertThat(result.isPresent()).isTrue();
-            final Profile profile = result.get();
-            assertThat(profile.getUsername()).isEqualTo(ALICE.getUsername());
-            assertThat(profile.getBio()).isEqualTo(ALICE.getBio());
-            assertThat(profile.getImage()).isEqualTo(ALICE.getImageUrl());
-            assertThat(profile.isFollowing()).isEqualTo(true);
+            assertCorrectProfile(result.get(), userFixture, true);
         });
     }
 
     @Test
-    void 팔로우중이_아닌_유저의_프로필_가져오기() {
+    void 유저네임을_이용해_팔로우중이_아닌_유저의_프로필_가져오기() {
         // given
         dbInitializer.유저들이_회원가입_돼있다();
+
         Long loginId = JOHN.getId();
-        String username = ALICE.getUsername();
+        UserFixtures userFixture = ALICE;
 
         // when
-        Optional<Profile> result = profileQueryRepository.findByLoginIdAndUsername(loginId, username);
+        Optional<Profile> result = profileQueryRepository.findByLoginIdAndUsername(loginId, userFixture.getUsername());
 
         // then
         assertAll(() -> {
             assertThat(result.isPresent()).isTrue();
-            final Profile profile = result.get();
-            assertThat(profile.getUsername()).isEqualTo(ALICE.getUsername());
-            assertThat(profile.getBio()).isEqualTo(ALICE.getBio());
-            assertThat(profile.getImage()).isEqualTo(ALICE.getImageUrl());
-            assertThat(profile.isFollowing()).isEqualTo(false);
+            assertCorrectProfile(result.get(), userFixture, false);
         });
 
+    }
+
+    @Test
+    void 유저id를_이용해_팔로우중인_유저의_프로필_가져오기() {
+        // given
+        dbInitializer.JOHN이_ALICE를_팔로우한다();
+
+        Long loginId = JOHN.getId();
+        UserFixtures userFixture = ALICE;
+
+        // when
+        Optional<Profile> result = profileQueryRepository.findByLoginIdAndUserId(loginId, userFixture.getId());
+
+        // then
+        assertAll(() -> {
+            assertThat(result.isPresent()).isTrue();
+            assertCorrectProfile(result.get(), userFixture, true);
+        });
+    }
+
+    @Test
+    void 유저id를_이용해_팔로우중이_아닌_유저의_프로필_가져오기() {
+        // given
+        dbInitializer.유저들이_회원가입_돼있다();
+
+        Long loginId = JOHN.getId();
+        UserFixtures userFixture = ALICE;
+
+        // when
+        Optional<Profile> result = profileQueryRepository.findByLoginIdAndUserId(loginId, userFixture.getId());
+
+        // then
+        assertAll(() -> {
+            assertThat(result.isPresent()).isTrue();
+            assertCorrectProfile(result.get(), userFixture, false);
+        });
+
+    }
+
+    @Test
+    void 타겟_유저들의_프로필_가져오기() {
+        // given
+        dbInitializer.JOHN이_ALICE와_BOB을_팔로우한다();
+
+        Long loginId = JOHN.getId();
+        ArrayList<UserFixtures> userFixtures = new ArrayList<>(Arrays.asList(ALICE, BOB));
+        Set<Long> ids = userFixtures.stream().map(UserFixtures::getId)
+            .collect(Collectors.toSet());
+
+        // when
+        Map<Long, Profile> result = profileQueryRepository.findByLoginIdAndIds(loginId,
+            ids);
+
+        // then
+        userFixtures.forEach((userFixture) ->
+            assertCorrectProfile(result.get(userFixture.getId()), userFixture, true)
+        );
+
+    }
+
+    private void assertCorrectProfile(Profile resultProfile, UserFixtures userFixture, boolean isFollowing) {
+        assertAll(() -> {
+            assertThat(resultProfile.getUsername()).isEqualTo(userFixture.getUsername());
+            assertThat(resultProfile.getBio()).isEqualTo(userFixture.getBio());
+            assertThat(resultProfile.getImage()).isEqualTo(userFixture.getImageUrl());
+            assertThat(resultProfile.isFollowing()).isEqualTo(isFollowing);
+        });
     }
 
 }

--- a/src/test/java/real/world/e2e/util/DBInitializer.java
+++ b/src/test/java/real/world/e2e/util/DBInitializer.java
@@ -44,4 +44,11 @@ public class DBInitializer {
         entityManager.persist(FollowFixtures.JOHN이_ALICE를_팔로우.생성());
     }
 
+    @Transactional
+    public void JOHN이_ALICE와_BOB을_팔로우한다() {
+        유저들이_회원가입_돼있다();
+        entityManager.persist(FollowFixtures.JOHN이_ALICE를_팔로우.생성());
+        entityManager.persist(FollowFixtures.JOHN이_BOB를_팔로우.생성());
+    }
+
 }

--- a/src/test/java/real/world/fixture/FollowFixtures.java
+++ b/src/test/java/real/world/fixture/FollowFixtures.java
@@ -1,6 +1,7 @@
 package real.world.fixture;
 
 import static real.world.fixture.UserFixtures.ALICE;
+import static real.world.fixture.UserFixtures.BOB;
 import static real.world.fixture.UserFixtures.JOHN;
 
 import lombok.Getter;
@@ -9,7 +10,8 @@ import real.world.domain.follow.entity.Follow;
 @Getter
 public enum FollowFixtures {
 
-    JOHN이_ALICE를_팔로우(JOHN, ALICE);
+    JOHN이_ALICE를_팔로우(JOHN, ALICE),
+    JOHN이_BOB를_팔로우(JOHN, BOB);
 
     private final UserFixtures follower;
 


### PR DESCRIPTION
##  📣요약
- ProifleQueryRepository 테스트 작성
- Projection constructor로 수정
-
## ✨ 세부 내용
### ProifleQueryRepository 작성
- #22 에서 작성된 매서드 test 작성.
- profile 객체와 관련된 assertion이 Test마다 들어가 포함되어 `assertCorrectProfile`함수로 작성. 
- 이전에 작성한 `QueryRepositoryTest` 추상 클래스 사용.

### Projection constructor
- Q클래스 생성자를 이용했던 query 생성을 projection construction으로 수정함.
