### PR TITLE
[Test] Article 다중 조회 테스트 작성

### DIFF
--- a/src/main/java/real/world/domain/article/service/ArticleQueryService.java
+++ b/src/main/java/real/world/domain/article/service/ArticleQueryService.java
@@ -44,17 +44,17 @@ public class ArticleQueryService {
     }
 
     public List<ArticleResponse> getArticles(Long loginId, Page page) {
-        final List<ArticleView> articleView = articleQueryRepository.findByLoginId(loginId, page);
-        setProfile(loginId, articleView);
-        return articleView.stream().map(ArticleResponse::of).toList();
+        final List<ArticleView> articleViews = articleQueryRepository.findByLoginId(loginId, page);
+        setProfile(loginId, articleViews);
+        return articleViews.stream().map(ArticleResponse::of).toList();
     }
 
     public List<ArticleResponse> getRecent(Long loginId, Page page, String tag, String author,
         String favorited) {
-        final List<ArticleView> articleView = articleQueryRepository.findRecent(loginId, page, tag,
+        final List<ArticleView> articleViews = articleQueryRepository.findRecent(loginId, page, tag,
             author, favorited);
-        setProfile(loginId, articleView);
-        return articleView.stream().map(ArticleResponse::of).toList();
+        setProfile(loginId, articleViews);
+        return articleViews.stream().map(ArticleResponse::of).toList();
     }
 
     private void setProfile(Long loginId, ArticleView articleView) {

--- a/src/test/java/real/world/domain/article/query/ArticleQueryRepositoryTest.java
+++ b/src/test/java/real/world/domain/article/query/ArticleQueryRepositoryTest.java
@@ -2,26 +2,29 @@ package real.world.domain.article.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static real.world.fixture.ArticleFixtures.게시물;
+import static real.world.fixture.ArticleFixtures.게시물_2;
+import static real.world.fixture.UserFixtures.ALICE;
+import static real.world.fixture.UserFixtures.JOHN;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import real.world.config.JpaConfig;
 import real.world.domain.article.entity.Article;
 import real.world.domain.article.repository.ArticleRepository;
+import real.world.domain.follow.entity.Follow;
+import real.world.domain.follow.repository.FollowRepository;
+import real.world.domain.global.Page;
 import real.world.domain.user.entity.User;
 import real.world.domain.user.repository.UserRepository;
-import real.world.fixture.ArticleFixtures;
-import real.world.fixture.UserFixtures;
+import real.world.support.QueryRepositoryTest;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaConfig.class, ArticleQueryRepositoryImpl.class})
-public class ArticleQueryRepositoryTest {
+@Import(ArticleQueryRepositoryImpl.class)
+public class ArticleQueryRepositoryTest extends QueryRepositoryTest {
+
 
     @Autowired
     private UserRepository userRepository;
@@ -30,56 +33,134 @@ public class ArticleQueryRepositoryTest {
     private ArticleRepository articleRepository;
 
     @Autowired
+    private FollowRepository followRepository;
+
+    @Autowired
     private ArticleQueryRepository articleQueryRepository;
 
     @Test
     void 아티클뷰를_ID로_단건_조회한다() {
         // given
-        final User user = UserFixtures.JOHN.생성();
-        userRepository.save(user);
+        final User john = userRepository.save(JOHN.ID없이_생성());
         final Set<String> tags = Set.of("tag1", "tag2");
-        final Article article = ArticleFixtures.게시물.태그와_함께_생성(user.getId(), tags);
-        articleRepository.save(article);
+        final Article article = articleRepository.save(게시물.태그와_함께_생성(john.getId(), tags));
 
         // when
-        final Optional<ArticleView> articleView = articleQueryRepository.findById(user.getId(),
+        final Optional<ArticleView> articleView = articleQueryRepository.findById(john.getId(),
             article.getId());
 
         // then
         assertAll(() -> {
-            assertThat(articleView.isPresent()).isTrue();
-            final ArticleView result = articleView.get();
-            assertThat(result.getTitle()).isEqualTo(article.getTitle());
-            assertThat(result.getDescription()).isEqualTo(article.getDescription());
-            assertThat(result.getSlug()).isEqualTo(article.getSlug());
-            assertThat(result.getBody()).isEqualTo(article.getBody());
-            assertThat(result.getTagList()).containsExactlyInAnyOrderElementsOf(tags);
+            assertThat(articleView).isPresent();
+            assertArticleView(articleView.get(), article, tags);
         });
     }
-    
+
     @Test
     void 아티클뷰를_슬럭으로_단건_조회한다() {
         // given
-        final User user = UserFixtures.JOHN.생성();
-        userRepository.save(user);
+        final User john = userRepository.save(JOHN.ID없이_생성());
         final Set<String> tags = Set.of("tag1", "tag2");
-        final Article article = ArticleFixtures.게시물.태그와_함께_생성(user.getId(), tags);
-        articleRepository.save(article);
+        final Article article = articleRepository.save(게시물.태그와_함께_생성(john.getId(), tags));
 
         // when
-        final Optional<ArticleView> articleView = articleQueryRepository.findBySlug(user.getId(),
+        final Optional<ArticleView> articleView = articleQueryRepository.findBySlug(JOHN.getId(),
             article.getSlug());
 
         // then
         assertAll(() -> {
             assertThat(articleView.isPresent()).isTrue();
-            final ArticleView result = articleView.get();
-            assertThat(result.getTitle()).isEqualTo(article.getTitle());
-            assertThat(result.getDescription()).isEqualTo(article.getDescription());
-            assertThat(result.getSlug()).isEqualTo(article.getSlug());
-            assertThat(result.getBody()).isEqualTo(article.getBody());
-            assertThat(result.getTagList()).containsExactlyInAnyOrderElementsOf(tags);
+            assertArticleView(articleView.get(), article, tags);
         });
+    }
+
+    @Test
+    void 아티클뷰를_ID로_여러건_조회한다() {
+        // given
+        final User john = userRepository.save(JOHN.ID없이_생성());
+        final User alice = userRepository.save(ALICE.ID없이_생성());
+        followRepository.save(new Follow(alice, john));
+
+        final Set<String> tags = Set.of("tag1", "tag2");
+        final Article article1 = articleRepository.save(게시물.태그와_함께_생성(alice.getId(), tags));
+        final Article article2 = articleRepository.save(게시물_2.태그와_함께_생성(alice.getId(), tags));
+
+        final Page page = new Page(0, 5);
+
+        // when
+        final List<ArticleView> articleView = articleQueryRepository.findByLoginId(john.getId(),
+            page);
+
+        // then
+        assertAll(() -> {
+            assertThat(articleView).hasSize(2);
+            assertThat(articleView).satisfiesExactlyInAnyOrder(
+                item -> assertArticleView(item, article1, tags),
+                item -> assertArticleView(item, article2, tags)
+            );
+        });
+    }
+
+    @Test
+    void 아티클뷰를_AUTHOR_조건으로_여러건_조회한다() {
+        // given
+        final User john = userRepository.save(JOHN.ID없이_생성());
+        final User alice = userRepository.save(ALICE.ID없이_생성());
+        followRepository.save(new Follow(alice, john));
+
+        final Set<String> tags = Set.of("tag1", "tag2");
+        final Article article1 = articleRepository.save(게시물.태그와_함께_생성(alice.getId(), tags));
+        final Article article2 = articleRepository.save(게시물_2.태그와_함께_생성(alice.getId(), tags));
+
+        final Page page = new Page(0, 5);
+
+        // when
+        final List<ArticleView> articleView = articleQueryRepository.findRecent(john.getId(),
+            page, null, alice.getUsername(), null);
+
+        // then
+        assertAll(() -> {
+            assertThat(articleView).hasSize(2);
+            assertThat(articleView).satisfiesExactlyInAnyOrder(
+                item -> assertArticleView(item, article1, tags),
+                item -> assertArticleView(item, article2, tags)
+            );
+        });
+    }
+
+    @Test
+    void 아티클뷰를_TAG_조건으로_여러건_조회한다() {
+        // given
+        final User john = userRepository.save(JOHN.ID없이_생성());
+        final User alice = userRepository.save(ALICE.ID없이_생성());
+        followRepository.save(new Follow(alice, john));
+
+        final Set<String> tags = Set.of("tag1", "tag2");
+        final Article article1 = articleRepository.save(게시물.태그와_함께_생성(alice.getId(), tags));
+        final Article article2 = articleRepository.save(게시물_2.태그와_함께_생성(alice.getId(), tags));
+
+        final Page page = new Page(0, 5);
+
+        // when
+        final List<ArticleView> articleView = articleQueryRepository.findRecent(john.getId(),
+            page, "tag1", null, null);
+
+        // then
+        assertAll(() -> {
+            assertThat(articleView).hasSize(2);
+            assertThat(articleView).satisfiesExactlyInAnyOrder(
+                item -> assertArticleView(item, article1, tags),
+                item -> assertArticleView(item, article2, tags)
+            );
+        });
+    }
+
+    private void assertArticleView(ArticleView articleView, Article article, Set<String> tags) {
+        assertThat(articleView.getTitle()).isEqualTo(article.getTitle());
+        assertThat(articleView.getDescription()).isEqualTo(article.getDescription());
+        assertThat(articleView.getSlug()).isEqualTo(article.getSlug());
+        assertThat(articleView.getBody()).isEqualTo(article.getBody());
+        assertThat(articleView.getTagList()).containsExactlyInAnyOrderElementsOf(tags);
     }
 
 }

--- a/src/test/java/real/world/domain/article/service/ArticleQueryServiceTest.java
+++ b/src/test/java/real/world/domain/article/service/ArticleQueryServiceTest.java
@@ -1,0 +1,227 @@
+package real.world.domain.article.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static real.world.fixture.ArticleFixtures.게시물;
+import static real.world.fixture.ArticleFixtures.게시물_2;
+import static real.world.fixture.UserFixtures.ALICE;
+import static real.world.fixture.UserFixtures.JOHN;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import real.world.domain.article.dto.response.ArticleResponse;
+import real.world.domain.article.query.ArticleQueryRepository;
+import real.world.domain.article.query.ArticleView;
+import real.world.domain.global.Page;
+import real.world.domain.profile.query.Profile;
+import real.world.domain.profile.query.ProfileQueryRepository;
+import real.world.error.exception.ArticleNotFoundException;
+import real.world.error.exception.UserIdNotExistException;
+
+@ExtendWith(MockitoExtension.class)
+public class ArticleQueryServiceTest {
+
+    @Mock
+    private ArticleQueryRepository articleQueryRepository;
+
+    @Mock
+    private ProfileQueryRepository profileQueryRepository;
+
+    @InjectMocks
+    private ArticleQueryService articleQueryService;
+
+    @Nested
+    class ID로_게시물_단건_조회는 {
+
+        @Test
+        void 정상_호출시_아티클_응답을_반환한다() {
+            // given
+            final Long loginId = JOHN.getId();
+
+            final Set<String> tags = Set.of("tag1", "tag2");
+            final ArticleView article = 게시물.프로필_없이_뷰_생성(JOHN.getId(), tags);
+            final Profile profile = JOHN.프로필_생성();
+
+            given(articleQueryRepository.findById(loginId, 1L)).willReturn(Optional.of(article));
+            given(profileQueryRepository.findByLoginIdAndUserId(loginId, loginId)).willReturn(Optional.of(profile));
+
+            // when
+            final ArticleResponse response = articleQueryService.getArticle(loginId, 1L);
+
+            // then
+            assertArticleResponse(response, article, profile);
+        }
+
+        @Test
+        void ID에_일치하는_게시물이_없다면_예외를_던진다() {
+            // given
+            final Long loginId = JOHN.getId();
+            final Long anyId = 1L;
+
+            // when & then
+            assertThatThrownBy(() -> articleQueryService.getArticle(loginId, anyId))
+                .isInstanceOf(ArticleNotFoundException.class);
+        }
+
+        @Test
+        void ID에_일치하는_유저가_없다면_예외를_던진다() {
+            // given
+            final Long loginId = JOHN.getId();
+
+            final Set<String> tags = Set.of("tag1", "tag2");
+            final ArticleView article = 게시물.프로필_없이_뷰_생성(JOHN.getId(), tags);
+            given(articleQueryRepository.findById(loginId, 1L)).willReturn(Optional.of(article));
+
+            // when & then
+            assertThatThrownBy(() -> articleQueryService.getArticle(loginId, 1L))
+                .isInstanceOf(UserIdNotExistException.class);
+        }
+
+    }
+
+    @Nested
+    class 슬럭으로_게시물_단건_조회는 {
+
+        @Test
+        void 정상_호출시_아티클_응답을_반환한다() {
+            // given
+            final Long loginId = JOHN.getId();
+
+            final Set<String> tags = Set.of("tag1", "tag2");
+            final ArticleView article = 게시물.프로필_없이_뷰_생성(JOHN.getId(), tags);
+            final Profile profile = JOHN.프로필_생성();
+
+            given(articleQueryRepository.findBySlug(loginId, article.getSlug())).willReturn(Optional.of(article));
+            given(profileQueryRepository.findByLoginIdAndUserId(loginId, loginId)).willReturn(Optional.of(profile));
+
+            // when
+            final ArticleResponse response = articleQueryService.getArticle(loginId, article.getSlug());
+
+            // then
+            assertArticleResponse(response, article, profile);
+        }
+
+        @Test
+        void 슬럭에_일치하는_게시물이_없다면_예외를_던진다() {
+            // given
+            final Long loginId = JOHN.getId();
+            final String anySlug = "slug1";
+
+            // when & then
+            assertThatThrownBy(() -> articleQueryService.getArticle(loginId, anySlug))
+                .isInstanceOf(ArticleNotFoundException.class);
+        }
+
+        @Test
+        void ID에_일치하는_유저가_없다면_예외를_던진다() {
+            // given
+            final Long loginId = JOHN.getId();
+
+            final Set<String> tags = Set.of("tag1", "tag2");
+            final ArticleView article = 게시물.프로필_없이_뷰_생성(JOHN.getId(), tags);
+
+            given(articleQueryRepository.findBySlug(loginId, article.getSlug())).willReturn(Optional.of(article));
+
+            // when & then
+            assertThatThrownBy(() -> articleQueryService.getArticle(loginId, article.getSlug()))
+                .isInstanceOf(UserIdNotExistException.class);
+        }
+
+    }
+
+    @Nested
+    class 팔로잉_피드_아티클_다수_조회는 {
+
+        @Test
+        void 정상_호출시_아티클_응답들을_반환한다() {
+            // given
+            final Long loginId = JOHN.getId();
+
+            final Set<String> tags = Set.of("tag1", "tag2");
+
+            final ArticleView article1 = 게시물.프로필_없이_뷰_생성(JOHN.getId(), tags);
+            final ArticleView article2 = 게시물_2.프로필_없이_뷰_생성(ALICE.getId(), tags);
+
+            final Profile profile1 = JOHN.프로필_생성();
+            final Profile profile2 = ALICE.프로필_생성();
+
+            final Page page = new Page(0, 5);
+            given(articleQueryRepository.findByLoginId(loginId, page)).willReturn(List.of(article1, article2));
+            given(profileQueryRepository.findByLoginIdAndIds(eq(loginId), anySet()))
+                .willReturn(Map.of(JOHN.getId(), profile1, ALICE.getId(), profile2));
+
+            // when
+            final List<ArticleResponse> responses = articleQueryService.getArticles(loginId, page);
+
+            // then
+            assertThat(responses).satisfiesExactlyInAnyOrder(
+                response -> assertArticleResponse(response, article1, profile1),
+                response -> assertArticleResponse(response, article2, profile2)
+            );
+        }
+
+    }
+
+    @Nested
+    class 피드_조건_아티클_다수_조회는 {
+
+        @Test
+        void 정상_호출시_아티클_응답들을_반환한다() {
+            // given
+            final Long loginId = JOHN.getId();
+
+            final Set<String> tags = Set.of("tag1", "tag2");
+
+            final ArticleView article1 = 게시물.프로필_없이_뷰_생성(JOHN.getId(), tags);
+            final ArticleView article2 = 게시물_2.프로필_없이_뷰_생성(ALICE.getId(), tags);
+
+            final Profile profile1 = JOHN.프로필_생성();
+            final Profile profile2 = ALICE.프로필_생성();
+
+            final Page page = new Page(0, 5);
+            given(articleQueryRepository.findRecent(eq(loginId), eq(page), any(), any(), any()))
+                .willReturn(List.of(article1, article2));
+            given(profileQueryRepository.findByLoginIdAndIds(eq(loginId), anySet()))
+                .willReturn(Map.of(JOHN.getId(), profile1, ALICE.getId(), profile2));
+
+            // when
+            final List<ArticleResponse> responses = articleQueryService
+                .getRecent(loginId, page, null, null, null);
+
+            // then
+            assertThat(responses).satisfiesExactlyInAnyOrder(
+                response -> assertArticleResponse(response, article1, profile1),
+                response -> assertArticleResponse(response, article2, profile2)
+            );
+        }
+
+    }
+
+    private void assertArticleResponse(ArticleResponse response, ArticleView articleView, Profile profile) {
+        assertAll(() -> {
+            assertThat(response.getTitle()).isEqualTo(articleView.getTitle());
+            assertThat(response.getDescription()).isEqualTo(articleView.getDescription());
+            assertThat(response.getSlug()).isEqualTo(articleView.getSlug());
+            assertThat(response.getBody()).isEqualTo(articleView.getBody());
+            assertThat(response.getTagList()).containsExactlyInAnyOrderElementsOf(articleView.getTagList());
+
+            assertThat(response.getAuthor().getUsername()).isEqualTo(profile.getUsername());
+            assertThat(response.getAuthor().getBio()).isEqualTo(profile.getBio());
+            assertThat(response.getAuthor().getImage()).isEqualTo(profile.getImage());
+        });
+    }
+
+}

--- a/src/test/java/real/world/domain/profile/query/ProfileQueryRepositoryTest.java
+++ b/src/test/java/real/world/domain/profile/query/ProfileQueryRepositoryTest.java
@@ -9,7 +9,10 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
-import real.world.e2e.util.DBInitializer;
+import real.world.domain.follow.entity.Follow;
+import real.world.domain.follow.repository.FollowRepository;
+import real.world.domain.user.entity.User;
+import real.world.domain.user.repository.UserRepository;
 import real.world.support.QueryRepositoryTest;
 
 @Import(ProfileQueryRepositoryImpl.class)
@@ -19,17 +22,22 @@ class ProfileQueryRepositoryTest extends QueryRepositoryTest {
     private ProfileQueryRepository profileQueryRepository;
 
     @Autowired
-    private DBInitializer dbInitializer;
+    private UserRepository userRepository;
+
+    @Autowired
+    private FollowRepository followRepository;
 
     @Test
     void 팔로우중인_유저의_프로필_가져오기() {
         // given
-        dbInitializer.JOHN이_ALICE를_팔로우한다();
-        Long loginId = JOHN.getId();
-        String username = ALICE.getUsername();
+        final User john = userRepository.save(JOHN.ID없이_생성());
+        final User alice = userRepository.save(ALICE.ID없이_생성());
+        followRepository.save(new Follow(alice, john));
+        final Long loginId = john.getId();
+        final String username = ALICE.getUsername();
 
         // when
-        Optional<Profile> result = profileQueryRepository.findByLoginIdAndUsername(loginId, username);
+        final Optional<Profile> result = profileQueryRepository.findByLoginIdAndUsername(loginId, username);
 
         // then
         assertAll(() -> {
@@ -45,7 +53,8 @@ class ProfileQueryRepositoryTest extends QueryRepositoryTest {
     @Test
     void 팔로우중이_아닌_유저의_프로필_가져오기() {
         // given
-        dbInitializer.유저들이_회원가입_돼있다();
+        final User john = userRepository.save(JOHN.ID없이_생성());
+        final User alice = userRepository.save(ALICE.ID없이_생성());
         Long loginId = JOHN.getId();
         String username = ALICE.getUsername();
 

--- a/src/test/java/real/world/fixture/ArticleFixtures.java
+++ b/src/test/java/real/world/fixture/ArticleFixtures.java
@@ -63,6 +63,14 @@ public enum ArticleFixtures {
         );
     }
 
+    public ArticleView 프로필_없이_뷰_생성(Long userId, Set<String> tags) {
+        return new ArticleView(
+            태그와_함께_생성(userId, tags),
+            false,
+            0
+        );
+    }
+
     public ArticleView 뷰_생성(User user) {
         final ArticleView articleView = new ArticleView(
             생성(user.getId()),

--- a/src/test/java/real/world/fixture/UserFixtures.java
+++ b/src/test/java/real/world/fixture/UserFixtures.java
@@ -1,16 +1,14 @@
 package real.world.fixture;
 
-import java.util.Collections;
 import lombok.Getter;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
+import real.world.domain.profile.query.Profile;
 import real.world.domain.user.dto.request.LoginRequest;
 import real.world.domain.user.dto.request.RegisterRequest;
 import real.world.domain.user.dto.request.UpdateRequest;
 import real.world.domain.user.entity.User;
-import real.world.security.service.CustomUserDetails;
 
 @Getter
 public enum UserFixtures {
@@ -41,6 +39,10 @@ public enum UserFixtures {
         return 지정된_ID로_생성(this.id);
     }
 
+    public User ID없이_생성() {
+        return 지정된_ID로_생성(null);
+    }
+
     public User 지정된_ID로_생성(Long id) {
         final User user = new User(
             this.username,
@@ -53,6 +55,10 @@ public enum UserFixtures {
         return user;
     }
 
+    public Profile 프로필_생성() {
+        return Profile.of(생성(), false);
+    }
+
     public RegisterRequest 회원가입을_한다() {
         final RegisterRequest request = new RegisterRequest();
         ReflectionTestUtils.setField(request, "username", this.username);
@@ -60,7 +66,7 @@ public enum UserFixtures {
         ReflectionTestUtils.setField(request, "email", this.email);
         return request;
     }
-    
+
     public LoginRequest 로그인을_한다() {
         final LoginRequest request = new LoginRequest();
         ReflectionTestUtils.setField(request, "email", this.email);
@@ -76,13 +82,6 @@ public enum UserFixtures {
         ReflectionTestUtils.setField(request, "bio", "updated_" + this.bio);
         ReflectionTestUtils.setField(request, "image", "updated_" + this.imageUrl);
         return request;
-    }
-
-    public CustomUserDetails 유저디테일() {
-        return new CustomUserDetails(
-            생성(),
-            Collections.singleton(new SimpleGrantedAuthority("USER_ROLE"))
-        );
     }
 
 }

--- a/src/test/java/real/world/support/QueryRepositoryTest.java
+++ b/src/test/java/real/world/support/QueryRepositoryTest.java
@@ -1,25 +1,11 @@
 package real.world.support;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import real.world.config.JpaConfig;
-import real.world.e2e.util.DBInitializer;
-import real.world.e2e.util.DatabaseCleaner;
 
 @DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaConfig.class, DBInitializer.class, DatabaseCleaner.class})
+@Import(JpaConfig.class)
 public abstract class QueryRepositoryTest {
-
-    @Autowired
-    private DatabaseCleaner databaseCleaner;
-
-    @BeforeEach
-    void clean() {
-        databaseCleaner.clean();
-    }
 
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,7 +12,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
       show_sql: true
     open-in-view: false
 


### PR DESCRIPTION
##  📣요약 
- Article 다중 조회 테스트 작성
## ✨ 세부 내용
### 기본 설정 변경
- 테스트 환경에서 `dialect` 설정을 제거
- `QueryRepositoryTest`는 `DatabaseCleaner`가 필요 없으므로 제거
- `@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)` 제거
  - 위의 `dialect` 설정과 엮여서 정상 인식되지 않던 문제가 있었음. 테스트 환경에선 기본적으로 H2-인메모리 DB를 사용하도록 설정되어 있으므로, 대체할 필요가 없음
### Article 다중 조회 테스트 작성
- E2E테스트는 #27 문제를 해결한 뒤 작성할 예정
- 그 외 유닛, 통합 테스트는 작성 완료